### PR TITLE
move the most popular languages to the top in alphabetical order

### DIFF
--- a/src/helpers/ValidLanguageList.js
+++ b/src/helpers/ValidLanguageList.js
@@ -3,10 +3,18 @@ import React from 'react';
 import langs from 'langs/data';
 
 var validLangs = [
+  {name: 'Arabic'},
+  {name: 'English'},
+  {name: 'French'},
+  {name: 'Hindi'},
+  {name: 'Russian'},
+  {name: 'Somali'},
+  {name: 'Spanish'},
+  {name: 'Chinese (Simplified)', '1': 'zh-cn', local: '廣東話'}, //
+  {name: 'Chinese (Traditional)', '1': 'zh-tw', local: '台語'}, //
   {name: 'Afrikaans'},
   {name: 'Albanian'},
   {name: 'Amharic'},
-  {name: 'Arabic'},
   {name: 'Armenian'},
   {name: 'Azerbaijani'},
   {name: 'Basque'},
@@ -16,19 +24,15 @@ var validLangs = [
   {name: 'Bulgarian'},
   {name: 'Catalan'},
   {name: 'Cebuano', '1': 'ceb', local: 'Bisaya'}, //
-  {name: 'Chinese (Simplified)', '1': 'zh-cn', local: '廣東話'}, //
-  {name: 'Chinese (Traditional)', '1': 'zh-tw', local: '台語'}, //
   {name: 'Corsican'},
   {name: 'Croatian'},
   {name: 'Czech'},
   {name: 'Danish'},
   {name: 'Dutch'},
-  {name: 'English'},
   {name: 'Esperanto'},
   {name: 'Estonian'},
   {name: 'Filipino', '1': 'tl', local: 'Wikang Filipino'},
   {name: 'Finnish'},
-  {name: 'French'},
   {name: 'Frisian', '1': 'fy', local: 'Noordfreesk'}, //
   {name: 'Galician'},
   {name: 'Georgian'},
@@ -39,7 +43,6 @@ var validLangs = [
   {name: 'Hausa'},
   {name: 'Hawaiian', '1': 'haw', local: 'ʻŌlelo Hawaiʻi'}, //
   {name: 'Hebrew'},
-  {name: 'Hindi'},
   {name: 'Hmong', '1': 'hmn', local: 'lol Hmongb'}, //
   {name: 'Hungarian'},
   {name: 'Icelandic', '1': 'is', local: 'Íslenska'}, //
@@ -78,7 +81,6 @@ var validLangs = [
   {name: 'Portuguese'},
   {name: 'Punjabi', '1': 'pa', local: 'पंजाबी'}, //
   {name: 'Romanian'},
-  {name: 'Russian'},
   {name: 'Samoan', '1': 'sm', local: 'Gagana Sāmoa'}, //
   {name: 'Gaelic'},
   {name: 'Serbian'},
@@ -88,8 +90,6 @@ var validLangs = [
   {name: 'Sinhala'},
   {name: 'Slovak'},
   {name: 'Slovene'},
-  {name: 'Somali'},
-  {name: 'Spanish'},
   {name: 'Sundanese'},
   {name: 'Swahili'},
   {name: 'Swedish'},


### PR DESCRIPTION
## Description

<!-- Describe your changes here -->

This is a temporary fix that allows to see the most popular languages -- they are moved to the top of the dropdown list. Languages are sorted alphabetically based on their english spelling. 

I am planning to add a search bar to the dropdown to make it possible to filter languages by typing letters.  

- Asana ticket: https://app.asana.com/0/1132189118126148/1163227869281073

## PR Checklist

<!-- Please validate your changes with the checklist below before marking for code review. -->

- [+] Assign @romellogoodman as a reviewer.
- [+] If your PR is not a hotfix, is it targeted for `dev`?
- [-] Unit and functional test coverage was added where applicable.
- [+] CI/CD passes for your PR.
- [+] Complex code is well documented with comments.
- [-] Does the original ticket have test instructions? If not add them below

## How to Test

<!-- Provide instructions for how to test/validate the changes. -->

- Go to the main page in the catalog
- Click on the language dropdown
- See first 9 languages:
      - Arabic
      - English
      - French
      - Hindi
      - Russian
      - Somali
      - Spanish
      - Chinese Simplified
      - Chinese Traditional 

The rest of the list wasn't changed. 