### PR TITLE
Fix/mobile locale selector

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -128,16 +128,16 @@ class AppConnectCatalog extends React.Component {
 
   changeLocale(newLocale) {
     //localStorage newLocale
-
     if (validLocales.indexOf(newLocale) < 0) {
       clearLocale();
-    } else if (newLocale !== this.state.locale) {
-      this.setState({
-        locale: newLocale,
-        content: fetchLocale(getLocale()),
-      });
+    } else {
+      setLocale(newLocale);
     }
-    setLocale(newLocale);
+
+    this.setState({
+      locale: newLocale,
+      content: fetchLocale(getLocale()),
+    });
   }
 
   translate(key) {
@@ -480,7 +480,6 @@ class AppConnectCatalog extends React.Component {
                     logo={logo}
                     nearAddress={nearAddress}
                     session={session}
-                    setNewLocale={this.changeLocale}
                     t={t}
                     user={user}
                     userData={userData}

--- a/src/components/LocaleForm.js
+++ b/src/components/LocaleForm.js
@@ -89,30 +89,23 @@ class LocaleForm extends React.Component {
   }
 
   handleSelectLanguage(languageCode, languageName) {
-    if (languageName !== 'English') {
-      this.setState({
-        selectedLanguage: languageCode,
-        selectedLanguageName: languageName,
-      });
-    }
+    this.setState({
+      selectedLanguage: languageCode,
+      selectedLanguageName: languageName,
+    });
   }
 
   handleNextClick(ev) {
+    if (this.state.selectedLocale) {
+      this.props.changeLocale(this.state.selectedLocale);
+    }
     if (typeof this.props.onLocaleSelect === 'function') {
       this.props.onLocaleSelect(
         this.state.selectedLocale,
         this.state.selectedLanguage,
         this.state.selectedLanguageName !== this.state.startingLang
       );
-      if (
-        this.state.selectedLocaleName &&
-        (this.state.selectedLanguage !== 'es_MX' ||
-          this.state.selectedLanguage !== 'intl')
-      ) {
-        window.location.reload(false);
-      }
     }
-
     /*if(this.state.selectedLanguageName !== this.state.startingLang && allowRedirect) {
       this.setState({
         reload: true
@@ -121,12 +114,9 @@ class LocaleForm extends React.Component {
   }
 
   handleSelectLocale(localeCode, localeName) {
-    if (localeCode !== 'es_MX' || localeCode !== 'intl') {
-      this.setState({
-        selectedLocale: localeCode,
-        selectedLocaleName: localeName,
-      });
-    }
+    this.setState({
+      selectedLocale: localeCode,
+    });
   }
 
   componentWillMount() {
@@ -137,7 +127,6 @@ class LocaleForm extends React.Component {
   }
 
   render() {
-    const {newLocale} = this.props;
     const {
       labelRow,
       searchButton,
@@ -174,7 +163,6 @@ class LocaleForm extends React.Component {
           <LocaleSelector
             label={localeLabel}
             handleSelectLocale={this.handleSelectLocale}
-            setNewLocale={newLocale}
           />
         </Grid>
         <Grid item xs={12} className={searchButton}>

--- a/src/components/LocaleSelector.js
+++ b/src/components/LocaleSelector.js
@@ -42,28 +42,18 @@ class LocaleSelector extends React.Component {
 
     this.handleSelectLocale = this.handleSelectLocale.bind(this);
     this.getLocaleNameFromCode = this.getLocaleNameFromCode.bind(this);
-    this.setNewLocale = this.setNewLocale.bind(this);
   }
 
   handleSelectLocale(localeCode, localeName) {
-    this.setState(
-      {
-        selectedLocale: localeCode,
-        selectedLocaleName: localeName,
-      },
-      this.setNewLocale(localeCode)
-    );
-
+    this.setState({
+      selectedLocale: localeCode,
+      selectedLocaleName: localeName,
+    });
+    if (this.props.setOnChange === true && typeof this.props.changeLocale === 'function') {
+      this.props.changeLocale(localeCode);
+    }
     if (typeof this.props.handleSelectLocale === 'function') {
       this.props.handleSelectLocale(localeCode, localeName);
-    }
-  }
-
-  setNewLocale(newLocale) {
-    if (newLocale !== this.state.selectedLocale) {
-      if (typeof this.props.setNewLocale === 'function') {
-        this.props.setNewLocale(newLocale);
-      }
     }
   }
 

--- a/src/components/MapPage.js
+++ b/src/components/MapPage.js
@@ -557,7 +557,6 @@ class MapPage extends React.Component {
   }
 
   render() {
-    const {setNewLocale} = this.props;
     let mapResources = [];
 
     if (
@@ -616,7 +615,6 @@ class MapPage extends React.Component {
                       handleResourceTypeSelect={this.handleResourceTypeSelect}
                       infographic={infographic}
                       nearAddress={this.props.nearAddress}
-                      newLocale={setNewLocale}
                       searching={this.state.searching}
                       searchDisabled={this.state.searchDisabled}
                       classes={null}

--- a/src/components/PageContainer.js
+++ b/src/components/PageContainer.js
@@ -11,6 +11,7 @@ import Static from './Static';
 class PageContainer extends React.Component {
   render() {
     const {
+      changeLocale,
       country,
       handleLogOut,
       handleMessageNew,
@@ -113,6 +114,7 @@ class PageContainer extends React.Component {
             path="/:locale/page/:pageName"
             render={(props) => (
               <Static
+                changeLocale={changeLocale}
                 handleMessageNew={handleMessageNew}
                 handleLogOut={handleLogOut}
                 handleRequestOpen={handleRequestOpen}

--- a/src/components/SearchForm.js
+++ b/src/components/SearchForm.js
@@ -85,7 +85,9 @@ class SearchForm extends React.Component {
             <Grid item xs={12}>
               <LocaleSelector
                 label={localeLabel}
+                setOnChange={true}
                 handleSelectLocale={this.props.onLocaleSelect}
+                changeLocale={this.props.changeLocale}
               />
             </Grid>
           </Grid>

--- a/src/components/SearchFormPage.js
+++ b/src/components/SearchFormPage.js
@@ -127,20 +127,32 @@ class SearchFormContainer extends React.Component {
 
   // First called when selecting a different country
   handleLocaleSelect(locale, language, hasLanguageChanged) {
+    let redirect = false;
     switch (locale) {
       case 'es_MX':
-        window.open('https://catalog.asylumconnect.org/es_MX/page/Mexico/');
+        redirect = `/${locale}/page/Mexico/`;
         break;
       case 'intl':
-        window.open(
-          'https://catalog.asylumconnect.org//intl/page/outside-US-and-Canada'
-        );
+        redirect = '/intl/page/outside-US-and-Canada';
         break;
       default:
         this.setState({
           locale: locale,
         });
+        if (this.state.locale !== locale) {
+          window.location.reload();
+        }
         break;
+    }
+
+    if (redirect) {
+      if (hasLanguageChanged) {
+        window.location = redirect + '#googtrans(' + language + ')';
+      } else {
+        this.props.history.push(redirect);
+      }
+    } else if (hasLanguageChanged) {
+      window.location.reload();
     }
   }
 
@@ -275,7 +287,7 @@ class SearchFormContainer extends React.Component {
                     {...this.props}
                     classes={null}
                     onLocaleReset={this.handleLocaleReset}
-                    // onLocaleSelect={this.handleLocaleSelect}
+                    onLocaleSelect={this.handleLocaleSelect}
                   />
                 ) : (
                   <LocaleForm

--- a/src/components/Static.js
+++ b/src/components/Static.js
@@ -178,8 +178,9 @@ class Static extends React.Component {
     const isMobile = this.props.width < breakpoints['sm'];
     const localeLabel = 'Select country';
 
-    if (isMobile) {
-      return (
+    return (
+      <>
+        {isMobile ?
         <Grid
           container
           alignItems="center"
@@ -208,17 +209,15 @@ class Static extends React.Component {
             <Grid item xs={12}>
               <LocaleSelector
                 label={localeLabel}
+                setOnChange={true}
                 locale={this.props.match.params.locale}
                 handleSelectLocale={this.handleLocaleSelect}
+                changeLocale={this.props.changeLocale}
               />
             </Grid>
           </Grid>
         </Grid>
-      );
-    }
-
-    return (
-      <>
+        : null}
         <Grid
           container
           alignItems="center"
@@ -226,9 +225,11 @@ class Static extends React.Component {
           spacing={0}
           className={classes.localeHeader}
         >
+        {!isMobile ?
           <Grid item xs={12} className={classes.subAnnouncement}>
             <SubAnnouncement />
           </Grid>
+        : null}
         </Grid>
         <div className="static--page-container">
           {this.state.loading ? (


### PR DESCRIPTION
## Description

<!-- Describe your changes here -->
Updated changeLocale function and cleaned up unnecessary props and functions, added window reload to switch statement in SearchFormPage in order to update locale when a new country has been selected. This allows users to go back from Mexico or International catalogs without issue.

Also cleaned up mobile view for MX and Intl and fixed drop down selector.
- Asana ticket:

## PR Checklist

<!-- Please validate your changes with the checklist below before marking for code review. -->

- [x] Assign @ShehryarKh as a reviewer.
- [x] If your PR is not a hotfix, is it targeted for `dev`?
- [ ] Unit and functional test coverage was added where applicable.
- [x] CI/CD passes for your PR.
- [ ] Complex code is well documented with comments.
- [x] Does the original ticket have test instructions? If not add them below

## How to Test

<!-- Provide instructions for how to test/validate the changes. -->
- Click on "Find Resources"
- Select a locale and click "Next"
- The search box should populate with addresses within locale
- Otherwise, MX/Intl page should load and user should be able to click back to search form
For mobile:
- Shrink screen
- Select locale
- Search form should populate with addresses within locale
- Otherwise, MX/Intl page should load and user should be able to go back to original screen by selecting new locale in drop down