### PR TITLE
Set window to scroll to top of page on service page select

### DIFF
--- a/src/components/DetailPage.js
+++ b/src/components/DetailPage.js
@@ -263,6 +263,8 @@ class Detail extends React.Component {
   }
 
   componentDidUpdate(prevProps, prevState) {
+    window.scrollTo(0, 0);
+
     const params = this.props?.match?.params;
     const oldParams = prevProps?.match?.params;
 

--- a/src/components/MapPage.js
+++ b/src/components/MapPage.js
@@ -621,7 +621,6 @@ class MapPage extends React.Component {
                     />
                   )}
                 />
-                }
                 <Route
                   path="/:locale/search/:in/:place/:near/:for/:filter/:sort"
                   render={(props) => (


### PR DESCRIPTION
## Description
Allow window to scroll to top of page from organization search when user clicks on service.

- Asana ticket: [link](https://app.asana.com/0/1132189118126148/1183780888536097/f)

## PR Checklist

<!-- Please validate your changes with the checklist below before marking for code review. -->

- [x] Assign @ShehryarKh as a reviewer.
- [x] If your PR is not a hotfix, is it targeted for `dev`?
- [x] Unit and functional test coverage was added where applicable.
- [x] CI/CD passes for your PR.
- [x] Complex code is well documented with comments.
- [x] Does the original ticket have test instructions? If not add them below

## How to Test
- From organization search results, click on an organization
- Scroll down to services section and click on any link to service
- Should render from top of the page
