### PR TITLE
Scroll window to top when page url updates

### DIFF
--- a/src/components/DetailPage.js
+++ b/src/components/DetailPage.js
@@ -263,11 +263,8 @@ class Detail extends React.Component {
   }
 
   componentDidUpdate(prevProps, prevState) {
-    window.scrollTo(0, 0);
-
     const params = this.props?.match?.params;
     const oldParams = prevProps?.match?.params;
-
     if (
       params.id !== oldParams.id ||
       params.serviceId !== oldParams.serviceId
@@ -275,6 +272,17 @@ class Detail extends React.Component {
       this.isServicePage = Boolean(params.id && params.serviceId);
 
       this.requestData();
+    }
+
+    // Checks current path from url and compares to path from prev page url
+    // If paths don't match, window will scroll to top
+    const newPath = this.props?.match?.path;
+    const oldPath = prevProps?.match?.path;
+    if (
+      newPath === '/:locale/resource/:id/service/:serviceId' &&
+      oldPath !== '/:locale/resource/:id/service/:serviceId'
+    ) {
+      window.scroll(0, 0);
     }
   }
 


### PR DESCRIPTION
## Description

Compares url on DetailPage with previous, allowing window to scroll to top of page when service is clicked.

- Asana ticket: [](https://app.asana.com/0/1132189118126148/1183780888536097/f)

## PR Checklist

<!-- Please validate your changes with the checklist below before marking for code review. -->

- [x] Assign @ShehryarKh as a reviewer.
- [x] If your PR is not a hotfix, is it targeted for `dev`?
- [x] Unit and functional test coverage was added where applicable.
- [x] CI/CD passes for your PR.
- [x] Complex code is well documented with comments.
- [x] Does the original ticket have test instructions? If not add them below

## How to Test

- From organization search results, click on an organization
- Scroll down to services section and click on any link to service
- Should render from top of the page
