### PR TITLE
Add new "Sponsors" subcategory to "Community Support" category on the U.S. Catalog

### DIFF
--- a/src/utils/tags.js
+++ b/src/utils/tags.js
@@ -42,6 +42,12 @@ const resourceTypes = [
     acTag: 'LGBTQ centres',
     title: 'LGBTQ centres',
   },
+  {
+    category: 'Community Support',
+    type: 'communitySupport',
+    acTag: 'Sponsors',
+    title: 'Sponsors',
+  },
 
   /* AC Computers and Internet Category */
   {
@@ -414,8 +420,9 @@ const localeExclusions = {
     'Private therapy and counseling',
     'Psychological evaluations for asylum claim',
     'Special Immigrant Juvenile Status (SIJS)',
+    'Sponsors'
   ],
-  en_MX: ['Gender-neutral bathrooms', 'Gender-neutral washrooms', 'Reception Services'],
+  en_MX: ['Gender-neutral bathrooms', 'Gender-neutral washrooms', 'Reception Services', 'Sponsors'],
 };
 const filterResourceType = function (item, locale) {
   if (typeof item.title !== 'undefined') {


### PR DESCRIPTION
## Description

Adds new "Sponsors" subcategory to "Community Support" category on the U.S. Catalog

- Asana ticket: https://app.asana.com/0/1132189118126148/1186705589820009/f

## PR Checklist

<!-- Please validate your changes with the checklist below before marking for code review. -->

- [x] If your PR is not a hotfix, is it targeted for `dev`?
- [x] Unit and functional test coverage was added where applicable.
- [x] CI/CD passes for your PR.
- [x] Complex code is well documented with comments.
- [x] Does the original ticket have test instructions? If not add them below

## How to Test

<!-- Provide instructions for how to test/validate the changes. -->
 Navigate to US Catalog search page
Click on 'Service Type' dropdown
Check option for Community Support > 'Sponsors'
Click 'Search'