### PR TITLE
Updates MX locale from es_MX to en_MX given that localization hasn't …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ hash-test*
 
 # Build js
 public/js
+.vscode

--- a/src/components/LocaleSelector.js
+++ b/src/components/LocaleSelector.js
@@ -25,7 +25,7 @@ const styles = (theme) => ({
 
 const supportedLocales = [
   {name: '🇨🇦 Canada', code: 'en_CA'},
-  {name: '🇲🇽 Mexico', code: 'es_MX'},
+  {name: '🇲🇽 Mexico', code: 'en_MX'},
   {name: '🇺🇸 United States', code: 'en_US'},
   {name: '🌎 Other / Travel Support', code: 'intl'},
 ];

--- a/src/utils/locale.js
+++ b/src/utils/locale.js
@@ -26,7 +26,7 @@ const enCA = {
 
 const enMX = {
   'Start typing county, city or state in the US…':
-    'Start typing city, province or territory in Mexico…',
+    'Start typing city or state in Mexico…',
   'Download Legal Guides on LGBTQ Asylum in the U.S.':
     'Download Legal Guides on LGBTQ Asylum in Mexico',
   'English classes': 'Language classes',
@@ -52,7 +52,7 @@ export const fetchLocale = (locale) => {
   switch (locale) {
     case 'en_CA':
       return enCA;
-    case 'es_MX':
+    case 'en_MX':
       return enMX;
     case 'en_US':
     default:
@@ -60,7 +60,7 @@ export const fetchLocale = (locale) => {
   }
 };
 
-export const validLocales = ['en_US', 'en_CA', 'es_MX'];
+export const validLocales = ['en_US', 'en_CA', 'en_MX'];
 
 export const clearLocale = () => {
   window.localStorage.removeItem('locale');
@@ -80,6 +80,6 @@ export const setLocale = (locale) => {
 
 export const localeTagMap = {
   en_CA: 'canada',
-  es_MX: 'mexico',
+  en_MX: 'mexico',
   en_US: 'united_states',
 };

--- a/src/utils/tags.js
+++ b/src/utils/tags.js
@@ -422,7 +422,7 @@ const localeExclusions = {
     'Special Immigrant Juvenile Status (SIJS)',
     'Sponsors'
   ],
-  es_MX: [
+  en_MX: [
     'Cultural centers',
     'Gender-neutral bathrooms', 
     'Gender-neutral washrooms', 


### PR DESCRIPTION
## Description

- Refactors "Start typing city, province or territory in Mexico..." to "Start typing city or state in Mexico...
- Updates MX locale from es_MX to en_MX given that localization hasn't been implemented and default language is still english. Adds vscode folder to gitignore

- Asana ticket:

## PR Checklist

<!-- Please validate your changes with the checklist below before marking for code review. -->

- [x] If your PR is not a hotfix, is it targeted for `dev`?
- [x] Unit and functional test coverage was added where applicable.
- [x] CI/CD passes for your PR.
- [x] Complex code is well documented with comments.
- [x] Does the original ticket have test instructions? If not add them below

## How to Test

1. Navigate to Catalog Home Page
2. Select 'Mexico' from 'Country' dropdown list
3. Verify that app displays search page for Mexico Catalog
