### PR TITLE
Addresses issue where icons for services in locales other than en_US would display as miscelleanous (AC)

### DIFF
--- a/src/components/DetailPage.js
+++ b/src/components/DetailPage.js
@@ -754,6 +754,7 @@ class Detail extends React.Component {
                                       list={resourceTags}
                                       classes={classes}
                                       isMobile={isMobile}
+                                      locale={locale}
                                     />
                                   }
                                 />
@@ -960,6 +961,7 @@ class Detail extends React.Component {
                                   list={resourceTags}
                                   classes={classes}
                                   isMobile={isMobile}
+                                  locale={locale}
                                 />
                               }
                             />

--- a/src/components/DetailServices.js
+++ b/src/components/DetailServices.js
@@ -18,7 +18,7 @@ const addBadges = (list, locale) => {
           ...(item?.areas?.length ? item.areas : []),
         ].sort();
 
-        item.badge = resourceTypes.getBadge(badgeList);
+        item.badge = resourceTypes.getBadge(badgeList, locale);
 
         return item;
       })

--- a/src/components/ResourceListItem.js
+++ b/src/components/ResourceListItem.js
@@ -20,8 +20,6 @@ import propertyMap, {combineProperties} from '../utils/propertyMap';
 import resourceTypes, {getTags, getOrgTags} from '../utils/tags';
 import {boldFont, breakpoints} from '../theme';
 
-let resourceIndex = resourceTypes.resourceIndex;
-
 const styles = (theme) => ({
   boldFont: boldFont(theme),
   contentSpacing: {
@@ -138,7 +136,7 @@ class ResourceListItem extends React.Component {
     const rating = resource.rating || resource.opportunity_aggregate_ratings;
     const commentCount =
       resource.opportunity_comment_count + resource.comment_count;
-
+      let resourceIndex = resourceTypes.getResourceIndex(locale);
     return (
       <div className={paperPadding}>
         {isMobile ? (

--- a/src/utils/tags.js
+++ b/src/utils/tags.js
@@ -519,8 +519,6 @@ const getResourceIndex = (locale = defaultLocale) => {
   return index;
 };
 
-const resourceIndex = getResourceIndex();
-
 const getResourceCategoryIndex = (locale = defaultLocale) => {
   let index = {};
   resourceTypes
@@ -541,7 +539,8 @@ const getResourceCategoryIndex = (locale = defaultLocale) => {
 
 const resourceCategoryIndex = getResourceCategoryIndex();
 
-const getBadge = (tags) => {
+const getBadge = (tags, locale) => {
+  const resourceIndex = getResourceIndex(locale);
   let badge = 'misc';
   tags.forEach((tag) => {
     if (typeof resourceIndex[tag] !== 'undefined' && badge === 'misc') {
@@ -595,7 +594,6 @@ export default {
   getResourceTypes,
   resourceTypesByGroup,
   getResourceTypesByGroup,
-  resourceIndex,
   getResourceIndex,
   resourceCategoryIndex,
   getResourceCategoryIndex,


### PR DESCRIPTION
## Description

 - refactors components that use 'resourceIndex' to utilize getResourceIndex function directly. 
 - refactors getResourceIndex calls such that param locale is passed. otherwise, locale defaults to 'en_US' which results in resource type icons not being displayed. 
- updates 'getBadge' calls so that locale is passed as param.
- updates instances where ServiceType component is being used but locale prop is not passed.

- Asana ticket: https://app.asana.com/0/1132189118126148/1199002609870845/f

## PR Checklist

<!-- Please validate your changes with the checklist below before marking for code review. -->

- [x] If your PR is not a hotfix, is it targeted for `dev`?
- [ ] Unit and functional test coverage was added where applicable.
- [x] CI/CD passes for your PR.
- [x] Complex code is well documented with comments.
- [ ] Does the original ticket have test instructions? If not add them below

## How to Test

1. Navigate to the AC Catalog
2. You can visit any of these pages to verify the icons are displaying correctly for each service:
   - https://asylum-connect-catalog-staging.herokuapp.com/en_CA/resource/the-519-toronto-on-canada
   - See "Get help getting a Mexican passport or U.S. visa" (associated tag not displaying: “Asylum application in the US from Mexico”): https://asylum-connect-catalog-staging.herokuapp.com/en_MX/resource/zorros-lgbt 
   - See "Learn Spanish" (associated tag not displaying: "Language classes"): https://asylum-connect-catalog-staging.herokuapp.com/en_MX/resource/sin-fronteras-iap

![image](https://user-images.githubusercontent.com/7406914/99204333-4d89af00-2783-11eb-9955-5b8dcb6e7346.png)

<img width="418" alt="image" src="https://user-images.githubusercontent.com/7406914/99204370-6db96e00-2783-11eb-9739-6efdeb03f06c.png">
