### PR TITLE
Updates service icons with labels in desktop dsearch results

### DIFF
--- a/src/components/ResourceListItem.js
+++ b/src/components/ResourceListItem.js
@@ -70,13 +70,20 @@ const styles = (theme) => ({
       paddingTop: theme.spacing(2),
     },
   },
-  badgeSpacing: {
+  badgeContainerSpacing: {
     [theme.breakpoints.down('xs')]: {
       marginLeft: theme.spacing(0),
       marginBottom: '0.75rem',
     },
-    marginLeft: theme.spacing(-1),
   },
+  badge: {
+   display: 'block'
+  },
+  badgeItem: {
+    marginRight: theme.spacing(2),
+    display: 'block',
+    textAlign: 'center'
+  }
 });
 
 class ResourceListItem extends React.Component {
@@ -110,11 +117,13 @@ class ResourceListItem extends React.Component {
       paperPadding,
       dividerPadding,
       dividerSpacing,
-      badgeSpacing,
+      badgeContainerSpacing,
       moreInfo,
       nationalOrg,
       orgName,
       pullLeft,
+      badge,
+      badgeItem
     } = classes;
     const isMobile = width < breakpoints['sm'];
     const displayData = [
@@ -215,7 +224,7 @@ class ResourceListItem extends React.Component {
                   spacing={0}
                   justify="space-between"
                 >
-                  <Grid item xs={12} md={6} className={badgeSpacing}>
+                  <Grid item xs={12} md={6} className={badgeContainerSpacing}>
                     {tags && tags.length
                       ? (() => {
                           let badges = [];
@@ -392,7 +401,7 @@ class ResourceListItem extends React.Component {
                   spacing={0}
                   justify="space-between"
                 >
-                  <Grid item xs={12} md={6} className={badgeSpacing}>
+                  <Grid item container xs={12} className={badgeContainerSpacing} alignItems='center'>
                     {tags && tags.length
                       ? (() => {
                           let badges = [];
@@ -403,12 +412,17 @@ class ResourceListItem extends React.Component {
                             ) {
                               badges.push(resourceIndex[tag].type);
                               return (
-                                <Badge
+                                <Grid item key={resourceIndex[tag].type} className={badgeItem}>
+                                  <Badge
                                   key={resourceIndex[tag].type}
                                   type={resourceIndex[tag].type}
                                   width="52px"
                                   height="52px"
                                 />
+                                <Typography variant='body2' component='span' className={badge}>
+                                  {resourceIndex[tag].category.split(' ')[0]}
+                                </Typography>
+                                </Grid>
                               );
                             }
 


### PR DESCRIPTION
## Description

Updates styling for service type icons on search results page
Adds service type label beneath service type icon on search results page

- Asana ticket: https://app.asana.com/0/1132189118126148/1195219695940619/f

## PR Checklist

<!-- Please validate your changes with the checklist below before marking for code review. -->

- [x] If your PR is not a hotfix, is it targeted for `dev`?
- [x] Unit and functional test coverage was added where applicable.
- [x] CI/CD passes for your PR.
- [x] Complex code is well documented with comments.
- [x] Does the original ticket have test instructions? If not add them below

## How to Test

1. Navigate to AC catalog
2. Perform a search
3. Note that service icons are now labelled with the name of the service type

<img width="1277" alt="image" src="https://user-images.githubusercontent.com/7406914/99294442-10203280-2812-11eb-9a6e-53dc2b37bc66.png">

