### PR TITLE
Feature/1195219695940622/service type label org page

### DIFF
--- a/src/components/DetailPage.js
+++ b/src/components/DetailPage.js
@@ -185,17 +185,17 @@ const styles = (theme) => ({
     },
   },
   serviceBadge: {
-    position: 'absolute',
-    marginLeft: theme.spacing(-1),
+    [theme.breakpoints.down('xs')]: {
+      position: 'absolute',
+      marginLeft: theme.spacing(-1),
+    }
   },
   serviceText: {
-    display: 'block',
+    display: 'inline-block',
     lineHeight: `${theme.spacing(0.5) + 45}px`,
-    paddingLeft: theme.spacing(7),
     marginTop: 0,
     marginBottom: 0,
     [theme.breakpoints.down('xs')]: {
-      display: 'inline-block',
       width: '90%',
       verticalAlign: 'top',
       lineHeight: 1.6,
@@ -242,6 +242,10 @@ const styles = (theme) => ({
     paddingLeft: '0',
     paddingRight: '0',
   },
+  badge: {
+   display: 'inline-block',
+   width: '18%'
+  },
 });
 
 class Detail extends React.Component {
@@ -251,11 +255,11 @@ class Detail extends React.Component {
     const {id, serviceId} = this.props?.match?.params;
 
     this.state = {
-      average_rating: null,
+      average_rating: 0,
       comments: [],
       modal: false,
       loading: true,
-      ratings: null,
+      ratings: 0,
       organization: null,
       service: null,
       tab: 0,

--- a/src/components/DetailServices.js
+++ b/src/components/DetailServices.js
@@ -8,9 +8,10 @@ import resourceTypes, {getTags} from '../utils/tags';
 
 // TODO: move to utils and test
 const addBadges = (list, locale) => {
+  const resourceIndex = resourceTypes.getResourceIndex(locale);
   return (
     list
-      ?.map((item) => {
+    ?.map((item) => {
         const itemTags = getTags(item, locale);
         const badgeList = [
           ...(itemTags?.length ? itemTags : []),
@@ -19,7 +20,9 @@ const addBadges = (list, locale) => {
         ].sort();
 
         item.badge = resourceTypes.getBadge(badgeList, locale);
-
+        if (typeof resourceIndex[badgeList[0]] !== 'undefined') {
+         item.label = resourceIndex[badgeList[0]].category
+        }
         return item;
       })
       ?.sort((first, second) => {
@@ -37,7 +40,7 @@ const addBadges = (list, locale) => {
 };
 
 const Services = (props) => {
-  const {classes, list, isMobile, locale, resource, resourceTags} = props;
+  const {classes, list, isMobile, locale, resource, badge} = props;
   const itemsWithBadges = addBadges(list, locale);
   let lastBadge = false;
 
@@ -45,11 +48,9 @@ const Services = (props) => {
     <Grid container spacing={0}>
       <Grid item xs={12} className={classes.sectionSpacing}>
         <Grid container spacing={0}>
-          <Grid item xs={12}>
             {itemsWithBadges.map((item) => {
               const {_id, badge, name, slug} = item;
               const itemLink = `/${locale}/resource/${resource.slug}/service/${slug}`;
-
               if (isMobile) {
                 let newType = false;
 
@@ -59,7 +60,7 @@ const Services = (props) => {
                 }
 
                 return (
-                  <div>
+                  <Grid item xs={12} key={_id}>
                     {newType && (
                       <ACBadge
                         extraClasses={{
@@ -77,20 +78,17 @@ const Services = (props) => {
                         {name}
                       </Link>
                     </li>
-                  </div>
+                  </Grid>
                 );
               }
 
               return (
-                <Typography
-                  key={_id}
-                  variant="body2"
-                  style={{position: 'relative'}}
-                >
+                <Grid item xs={12} key={_id}>
+                
                   {badge ? (
+                    <>
                     <ACBadge
                       extraClasses={{
-                        icon: classes.serviceBadge,
                         tooltip: classes.serviceTooltip,
                       }}
                       key="misc"
@@ -98,10 +96,13 @@ const Services = (props) => {
                       width="48px"
                       height="48px"
                     />
+                    <Typography variant='body2' component='span' className={classes.badge}>
+                      {item.label?.split(' ')[0]}
+                    </Typography>
+                    </>
                   ) : (
                     <ACBadge
                       extraClasses={{
-                        icon: classes.serviceBadge,
                         tooltip: classes.serviceTooltip,
                       }}
                       key="misc"
@@ -110,13 +111,20 @@ const Services = (props) => {
                       height="45px"
                     />
                   )}
+                  <Typography
+                  key={_id}
+                  variant="body2"
+                  component="span"
+                  style={{position: 'relative'}}
+                >
                   <Link to={itemLink} className={classes.serviceText}>
                     {name}
                   </Link>
                 </Typography>
+              </Grid>
               );
             })}
-          </Grid>
+
         </Grid>
       </Grid>
     </Grid>

--- a/src/components/ResourceRatingAndReviews.js
+++ b/src/components/ResourceRatingAndReviews.js
@@ -18,6 +18,10 @@ const RatingAndReviews = ({rating, total, classes}) => (
   </div>
 );
 
+RatingAndReviews.defaultProps = {
+  total: 0,
+  rating: 0,
+};
 RatingAndReviews.propTypes = {
   total: PropTypes.number,
   rating: PropTypes.number.isRequired,

--- a/src/components/ResourceRatingControl.js
+++ b/src/components/ResourceRatingControl.js
@@ -144,6 +144,7 @@ RatingControl.propTypes = {
 
 RatingControl.defaultProps = {
   mode: 'static',
+  rating: 0
 };
 
 export default withStyles(styles)(withWidth(RatingControl));


### PR DESCRIPTION
## Description

Adds service icon labels to right of service icons on organization detail page

- Asana ticket: https://app.asana.com/0/1132189118126148/1195219695940622/f

## PR Checklist

<!-- Please validate your changes with the checklist below before marking for code review. -->

- [x] If your PR is not a hotfix, is it targeted for `dev`?
- [x] Unit and functional test coverage was added where applicable.
- [x] CI/CD passes for your PR.
- [x] Complex code is well documented with comments.
- [x] Does the original ticket have test instructions? If not add them below

## How to Test

1. Navigate to AC catalog
2. Select a country from the country dropdown and click "Search"
3. enter a location in the location typeahead dropdown and click "Search"
4. Click an organization in the search results to view the organization detail page
5. Verify that each service listed has an icon and label associated with it (exceptions: services tagged "miscellaneous")


<img width="731" alt="image" src="https://user-images.githubusercontent.com/7406914/99576046-7c806a80-29a7-11eb-8cda-a104a493a10f.png">

