### PR TITLE
adds drop shadow to desktop, mobile and tablet navs

### DIFF
--- a/src/components/NavDesktop.js
+++ b/src/components/NavDesktop.js
@@ -39,6 +39,7 @@ const styles = (theme) => ({
     '@media(max-width:1315px)': {
       padding: '10px 0',
     },
+    boxShadow: '0px 2px 5px rgba(0, 0, 0, 0.3)'
   },
   displayInherit: {
     display: 'inherit',

--- a/src/components/NavMobile.js
+++ b/src/components/NavMobile.js
@@ -30,6 +30,7 @@ const styles = (theme) => {
       bottom: '0',
       zIndex: '100',
       borderTop: '1px solid ' + theme.palette.common.faintBlack,
+      boxShadow: '0px 2px 5px rgba(0, 0, 0, 0.3)'
     },
     navButton: Object.assign({}, theme.typography.body1, {
       fontSize: theme.typography.body1.fontSize - 2,

--- a/src/components/NavTablet.js
+++ b/src/components/NavTablet.js
@@ -12,6 +12,7 @@ import Grid from '@material-ui/core/Grid';
 const styles = (theme) => ({
   root: {
     padding: '10 0 10 0',
+    boxShadow: '0px 2px 5px rgba(0, 0, 0, 0.3)'
   },
   viewYourFavoritesText: {
     color: theme.palette.secondary[500],


### PR DESCRIPTION
## Description

adds drop shadow to desktop, mobile and tablet navs

- Asana ticket: https://app.asana.com/0/1132189118126148/1195219695940610/f

## PR Checklist

<!-- Please validate your changes with the checklist below before marking for code review. -->

- [x] If your PR is not a hotfix, is it targeted for `dev`?
- [x] Unit and functional test coverage was added where applicable.
- [x] CI/CD passes for your PR.
- [x] Complex code is well documented with comments.
- [x] Does the original ticket have test instructions? If not add them below

## How to Test

1. Navigate to the AC catalog homepage
2. Observe the slight shadow on the nav bar

### Desktop
<img width="1197" alt="image" src="https://user-images.githubusercontent.com/7406914/99587286-e2282300-29b6-11eb-8115-a859237c0da5.png">

### Tablet (horizontal)
<img width="747" alt="image" src="https://user-images.githubusercontent.com/7406914/99587399-0be14a00-29b7-11eb-90d8-08f8a7cc30ea.png">

### Mobile
<img width="306" alt="image" src="https://user-images.githubusercontent.com/7406914/99587530-38956180-29b7-11eb-80a5-d02514c4ca09.png">
