### PR TITLE
Move local storage lastSearch setItem to fetchSearchResults()

### DIFF
--- a/src/components/MapPage.js
+++ b/src/components/MapPage.js
@@ -106,15 +106,6 @@ class MapPage extends React.Component {
     window.removeEventListener('resize', this.resizeMap.bind(this));
   }
 
-  getSnapshotBeforeUpdate() {
-    if (
-      this.props.match.path ===
-      '/:locale/search/:in/:place/:near/:national/:for/:filter/:sort'
-    ) {
-      localStorage.setItem('lastSearch', this.props.history.location.pathname);
-    }
-  }
-
   componentWillUpdate(nextProps, nextState) {
     // TODO: drastically slowed the page down by causing constant re-rendering
     // if (
@@ -443,6 +434,7 @@ class MapPage extends React.Component {
             isNational,
           };
           this.setState(nextState);
+          localStorage.setItem('lastSearch', this.props.history.location.pathname);
 
           fetchOrganizations(params).then((data) =>
             this.processSearchResults(data, nextPage)

--- a/src/components/MapPage.js
+++ b/src/components/MapPage.js
@@ -106,6 +106,15 @@ class MapPage extends React.Component {
     window.removeEventListener('resize', this.resizeMap.bind(this));
   }
 
+  getSnapshotBeforeUpdate() {
+    if (
+      this.props.match.path ===
+      '/:locale/search/:in/:place/:near/:national/:for/:filter/:sort'
+    ) {
+      localStorage.setItem('lastSearch', this.props.history.location.pathname);
+    }
+  }
+
   componentWillUpdate(nextProps, nextState) {
     // TODO: drastically slowed the page down by causing constant re-rendering
     // if (


### PR DESCRIPTION
## Description

Move local storage lastSearch setItem to fetchSearchResults()

- Asana ticket:  1198403149891005

## PR Checklist

<!-- Please validate your changes with the checklist below before marking for code review. -->

- [ ] Assign @ShehryarKh as a reviewer.
- [ ] If your PR is not a hotfix, is it targeted for `dev`?
- [ ] Unit and functional test coverage was added where applicable.
- [ ] CI/CD passes for your PR.
- [ ] Complex code is well documented with comments.
- [ ] Does the original ticket have test instructions? If not add them below

## How to Test

Search for resources in catalog.
Click to examine any resource.
Click 'Back to search results'.
Search results are retained.
