### PR TITLE
fix: org primary number not being listed as default on org page

### DIFF
--- a/src/components/DetailHeader.js
+++ b/src/components/DetailHeader.js
@@ -103,6 +103,7 @@ const DetailHeader = ({
             {phones && phones.length ? (
               <Phone phone={phones[0]} classes={classes} />
             ) : null}
+            {phones && phones.length ? '| ' : null}
             {verified ? (
               <Tooltip
                 classes={{tooltipPlacementTop: 'badge-tooltipTop'}}

--- a/src/components/DetailPage.js
+++ b/src/components/DetailPage.js
@@ -184,6 +184,9 @@ const styles = (theme) => ({
       marginTop: theme.spacing(2),
     },
   },
+  serviceItemContainer: {
+    marginBottom: theme.spacing(2)
+  },
   serviceBadge: {
     [theme.breakpoints.down('xs')]: {
       position: 'absolute',
@@ -192,9 +195,11 @@ const styles = (theme) => ({
   },
   serviceText: {
     display: 'inline-block',
-    lineHeight: `${theme.spacing(0.5) + 45}px`,
     marginTop: 0,
-    marginBottom: 0,
+    lineHeight: 1.6,
+    [theme.breakpoints.down('sm')]: {
+      marginLeft: theme.spacing(1)
+    },
     [theme.breakpoints.down('xs')]: {
       width: '90%',
       verticalAlign: 'top',
@@ -243,8 +248,7 @@ const styles = (theme) => ({
     paddingRight: '0',
   },
   badge: {
-   display: 'inline-block',
-   width: '18%'
+   display: 'inline-block'
   },
   editButton: {
     width: '44px',
@@ -496,7 +500,8 @@ class Detail extends React.Component {
     }`;
     const isMobile = width < breakpoints['sm'];
     let sharePath = `resource/${organization?._id}/${organization?.name}`;
-
+    const primaryPhone = phones?.length > 0 ? 
+      phones?.filter(phone => phone?.is_primary) : null
     if (this.isServicePage) {
       sharePath += `/service/${service?.name}`;
     }
@@ -506,7 +511,7 @@ class Detail extends React.Component {
       classes,
       isMobile,
       name,
-      phones,
+      phones: primaryPhone || phones,
       rating: average_rating,
       totalRatings: ratings?.length,
       website,
@@ -708,7 +713,6 @@ class Detail extends React.Component {
                     name={name}
                     orgLink={`/${locale}/resource/${organization?.slug}`}
                     orgName={organization?.name}
-                    phones={phones}
                     rating={average_rating}
                     tab={tab}
                     tabs={this.tabs}
@@ -836,7 +840,7 @@ class Detail extends React.Component {
                               email={emails[0]}
                               list={service.access_instructions}
                               location={locations[0]}
-                              phone={phones[0]}
+                              phone={primaryPhone[0] || phones[0]}
                               rawSchedule={schedules[0]}
                               website={website}
                             />
@@ -1041,7 +1045,7 @@ class Detail extends React.Component {
                           email={emails[0]}
                           list={service.access_instructions}
                           location={locations[0]}
-                          phone={phones[0]}
+                          phone={primaryPhone[0] || phones[0]}
                           rawSchedule={schedules[0]}
                           website={website}
                         />

--- a/src/components/DetailServices.js
+++ b/src/components/DetailServices.js
@@ -11,7 +11,7 @@ const addBadges = (list, locale) => {
   const resourceIndex = resourceTypes.getResourceIndex(locale);
   return (
     list
-    ?.map((item) => {
+      ?.map((item) => {
         const itemTags = getTags(item, locale);
         const badgeList = [
           ...(itemTags?.length ? itemTags : []),
@@ -21,7 +21,7 @@ const addBadges = (list, locale) => {
 
         item.badge = resourceTypes.getBadge(badgeList, locale);
         if (typeof resourceIndex[badgeList[0]] !== 'undefined') {
-         item.label = resourceIndex[badgeList[0]].category
+          item.label = resourceIndex[badgeList[0]].category;
         }
         return item;
       })
@@ -48,47 +48,23 @@ const Services = (props) => {
     <Grid container spacing={0}>
       <Grid item xs={12} className={classes.sectionSpacing}>
         <Grid container spacing={0}>
-            {itemsWithBadges.map((item) => {
-              const {_id, badge, name, slug} = item;
-              const itemLink = `/${locale}/resource/${resource.slug}/service/${slug}`;
-              if (isMobile) {
-                let newType = false;
+          {itemsWithBadges.map((item) => {
+            const {_id, badge, name, slug} = item;
+            const itemLink = `/${locale}/resource/${resource.slug}/service/${slug}`;
+            if (isMobile) {
+              let newType = false;
 
-                if (lastBadge !== badge) {
-                  newType = true;
-                  lastBadge = badge;
-                }
-
-                return (
-                  <Grid item xs={12} key={_id}>
-                    {newType && (
-                      <ACBadge
-                        extraClasses={{
-                          icon: classes.serviceBadge,
-                          tooltip: classes.serviceTooltip,
-                        }}
-                        key="misc"
-                        type={badge}
-                        width="48px"
-                        height="48px"
-                      />
-                    )}
-                    <li>
-                      <Link to={itemLink} className={classes.serviceText}>
-                        {name}
-                      </Link>
-                    </li>
-                  </Grid>
-                );
+              if (lastBadge !== badge) {
+                newType = true;
+                lastBadge = badge;
               }
 
               return (
                 <Grid item xs={12} key={_id}>
-                
-                  {badge ? (
-                    <>
+                  {newType && (
                     <ACBadge
                       extraClasses={{
+                        icon: classes.serviceBadge,
                         tooltip: classes.serviceTooltip,
                       }}
                       key="misc"
@@ -96,9 +72,45 @@ const Services = (props) => {
                       width="48px"
                       height="48px"
                     />
-                    <Typography variant='body2' component='span' className={classes.badge}>
-                      {item.label?.split(' ')[0]}
-                    </Typography>
+                  )}
+                  <li>
+                    <Link to={itemLink} className={classes.serviceText}>
+                      {name}
+                    </Link>
+                  </li>
+                </Grid>
+              );
+            }
+
+            return (
+              <Grid
+                item
+                container
+                xs={12}
+                key={_id}
+                alignItems="center"
+                alignContent="center"
+                className={classes.serviceItemContainer}
+              >
+                <Grid item xs={12} md={3}>
+                  {badge ? (
+                    <>
+                      <ACBadge
+                        extraClasses={{
+                          tooltip: classes.serviceTooltip,
+                        }}
+                        key="misc"
+                        type={badge}
+                        width="48px"
+                        height="48px"
+                      />
+                      <Typography
+                        variant="body2"
+                        component="span"
+                        className={classes.badge}
+                      >
+                        {item.label?.split(' ')[0]}
+                      </Typography>
                     </>
                   ) : (
                     <ACBadge
@@ -111,20 +123,15 @@ const Services = (props) => {
                       height="45px"
                     />
                   )}
-                  <Typography
-                  key={_id}
-                  variant="body2"
-                  component="span"
-                  style={{position: 'relative'}}
-                >
-                  <Link to={itemLink} className={classes.serviceText}>
-                    {name}
-                  </Link>
-                </Typography>
+                </Grid>
+                <Grid item xs={12} md={9}>
+                  <Typography key={_id} variant="body2" className={classes.serviceText}>
+                    <Link to={itemLink}>{name}</Link>
+                  </Typography>
+                </Grid>
               </Grid>
-              );
-            })}
-
+            );
+          })}
         </Grid>
       </Grid>
     </Grid>


### PR DESCRIPTION
## Description

addresses issue where primary phone would not be displayed as the default phone number on org page. addresses styling issues with service listing on org page.

- Asana ticket:
https://app.asana.com/0/1132189118126148/1199210612350829/f

## PR Checklist

<!-- Please validate your changes with the checklist below before marking for code review. -->

- [x] If your PR is not a hotfix, is it targeted for `dev`?
- [x] Unit and functional test coverage was added where applicable.
- [x] CI/CD passes for your PR.
- [x] Complex code is well documented with comments.
- [x] Does the original ticket have test instructions? If not add them below

## How to Test

- Navigate to the AC Control Panel
- Identify an organization with multiple phone numbers
- Click "View" to view the organization page on the control panel
- Click "View on Catalog" to view the organization page on the AC Catalog
- Verify that the phone number (or one of the phone numbers) marked as primary is shown in the detail header on the organization page

<img width="1257" alt="Screenshot 2020-12-09 at 12 19 12 PM" src="https://user-images.githubusercontent.com/7406914/101663574-e0330c00-3a18-11eb-9188-a487d4cbcabe.png">

<img width="747" alt="Screenshot 2020-12-09 at 12 16 01 PM" src="https://user-images.githubusercontent.com/7406914/101663278-816d9280-3a18-11eb-931f-3e650e0f4650.png">

