### PR TITLE
adds locale option for es mx

### DIFF
--- a/src/utils/locale.js
+++ b/src/utils/locale.js
@@ -20,7 +20,7 @@ const enCA = {
 		'Psychological evaluations for refugee claim',
 	'Career counseling': 'Career counselling',
 	'Private therapy and counseling': 'Private therapy and counselling',
-	'39.8333333': '60.8545463',
+	39.8333333: '60.8545463',
 	'-98.585522': '-98.585522'
 };
 
@@ -44,7 +44,7 @@ const enMX = {
 		'Psychological evaluations for refugee claim',
 	'Career counseling': 'Career counselling',
 	'Private therapy and counseling': 'Private therapy and counselling',
-	'39.8333333': '23.634501',
+	39.8333333: '23.634501',
 	'-98.585522': '-102.552784'
 };
 
@@ -81,5 +81,6 @@ export const setLocale = (locale) => {
 export const localeTagMap = {
 	en_CA: 'canada',
 	en_MX: 'mexico',
-	en_US: 'united_states'
+	en_US: 'united_states',
+	es_MX: 'mexico'
 };


### PR DESCRIPTION
## Description
changes 'view on catalog' options to be country based vs language based to allow for viewing of CA orgs to work correctly.
Issue was raised by data entry intern


![image](https://user-images.githubusercontent.com/7406914/122411265-9dffff80-cf52-11eb-9e6c-c0f5b121faec.png)
![image](https://user-images.githubusercontent.com/7406914/122413174-2c28b580-cf54-11eb-9cfa-567b1b85db93.png)


## Asana ticket: N/A

## PR Checklist

<!-- Please validate your changes with the checklist below before marking for code review. -->

- [x] Assign @FJKhan **and** @Alfredo-Moreira as reviewers.
- [x] If your PR is not a hotfix, is it targeted for `dev`? If your PR is a hotfix, is it targeted for `master`?
- [ ] Unit and functional test coverage was added where applicable.
- [x] CI/CD passes for your PR.
- [ ] Complex code is well documented with comments.
- [ ] Does the original ticket have test instructions? If not add them below

## How to Test

1. navigate to control panel
2. log in
3. view an organization
4. click "view on catalog" and select appropriate catalog option i.e. org country is based in
5. verify that user is routed to correct org page on catalog and that the services icons are displayed correctly


## Known issues
The FE catalog isn't yet refactored to display the org information entered in the ES postfixed fields. The headings will be present, but the information will not.
This will be addressed in [this ticket](https://app.asana.com/0/1132189118126148/1200486114359751/f)