### PR TITLE
fixes city/county service area property mismatch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,7 @@ jobs:
       - save_cache:
          paths:
           - node_modules
+          - "~./cache/Cypress"
          key: v1-dependencies-{{ checksum "package.json" }}
       - run:
           name: Compile Binary
@@ -58,10 +59,14 @@ jobs:
       - run:
           name: Install NYC
           command: npm i nyc
+      - run:
+          name: Install cypress
+          command: npm i cypress
       #save cache for use next tests
       - save_cache:
          paths:
           - node_modules
+          - "~./cache/Cypress"
          key: v1-dependencies-{{ checksum "package.json" }}
       - run:
           name: "Pre E2E Commands"

--- a/cypress/integration/announcement_spec.js
+++ b/cypress/integration/announcement_spec.js
@@ -1,0 +1,30 @@
+/* eslint-disable no-unused-expressions */
+/* eslint-disable no-undef */
+/// <reference types="cypress" />
+
+//compound url
+
+//Test Suite
+describe('Home Suggest New Resource Tests', () => {
+    let viewports = [Cypress.env('desktop'),Cypress.env('tablet')];
+    
+    beforeEach(() => {
+        cy.visit(Cypress.env('baseUrl'));
+    });
+
+     //Root
+     it('Root Test - Elements', () => {
+        cy.root().should('match', 'html');
+    });
+
+    //Components and Action
+    viewports.forEach(viewport=>{
+        context(`Testing the ${viewport} Version of the application`,()=>{
+                it(`Announcement Testing`,()=>{
+                        cy.testAnnouncementBannerElementsAndActions(viewport);
+                    }); 
+                });
+            });
+
+
+});

--- a/cypress/integration/change_language_spec.js
+++ b/cypress/integration/change_language_spec.js
@@ -1,0 +1,29 @@
+/* eslint-disable no-unused-expressions */
+/* eslint-disable no-undef */
+/// <reference types="cypress" />
+
+
+//compound url
+
+//Test Suite
+describe('Home Page Create Account Form Tests', () => {
+
+    let viewports = [Cypress.env('desktop'),Cypress.env('tablet'),Cypress.env('mobile')];
+
+    beforeEach(() => {
+        cy.visit(Cypress.env('baseUrl'));
+    });
+
+    //Root
+    it('Root Test - Elements', () => {
+        cy.root().should('match', 'html');
+    });
+
+    viewports.forEach(viewport=>{
+        context(`Testing the ${viewport} Version of the application`,()=>{
+                it.only(`Change Language Testing`,()=>{
+                        cy.testLanguageAction(viewport);
+                    }); 
+                });
+            });
+});

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -27,6 +27,7 @@ import './reusable_tests/footer_bar';
 import './reusable_tests/suggest_resource';
 import './reusable_tests/search_page';
 import './reusable_tests/announcement';
+import './reusable_tests/language';
 
 
 // Alternatively you can use CommonJS syntax:

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -26,6 +26,7 @@ import './reusable_tests/favorites';
 import './reusable_tests/footer_bar';
 import './reusable_tests/suggest_resource';
 import './reusable_tests/search_page';
+import './reusable_tests/announcement';
 
 
 // Alternatively you can use CommonJS syntax:

--- a/cypress/support/reusable_tests/announcement.js
+++ b/cypress/support/reusable_tests/announcement.js
@@ -1,0 +1,42 @@
+Cypress.Commands.add('testAnnouncementBannerElementsAndActions',(viewport)=>{
+    cy.viewport(viewport);
+    cy.getElementByTestId('announcement-header').then($element=>{
+        expect($element).to.be.visible;
+        expect($element).contain('Users contact service providers at their own risk.');
+    });
+    cy.getElementByTestId('announcement-disclaimer-button').then($element=>{
+        expect($element).to.be.visible;
+        expect($element).contain('Disclaimer');
+        cy.wrap($element).click();
+        cy.getElementByTestId('dialog-container-title').then($element=>{
+            expect($element).to.be.visible;
+            expect($element).contain('AsylumConnect Disclaimer');
+        });
+        cy.getElementByTestId('disclaimer-text').then($element=>{
+            expect($element).to.be.visible;
+            expect($element).contain('The AsylumConnect team will do its best to confirm the eligibility and basic facts about service providers listed on this website. However, we cannot guarantee the viability or capabilities of any such providers. Consequently, AsylumConnect assumes no responsibility for the actions of providers listed on this website and asylum seekers who contact any such providers do so at their own risk.')
+        });
+        cy.getElementByTestId('dialog-button').then($element=>{
+            expect($element).to.be.visible;
+            expect($element.children()).contain('OK');
+            expect($element).to.have.attr('type','submit');
+            cy.wrap($element).click();
+        });
+
+    });
+    cy.getElementByTestId('announcement-privacy-button').then($element=>{
+        expect($element).to.be.visible;
+        expect($element).contain('User Privacy Statement');
+        cy.wrap($element).click();
+        cy.getElementByTestId('dialog-container-title').then($element=>{
+            expect($element).to.be.visible;
+            expect($element).contain('AsylumConnect User Privacy Statement');
+        });
+        cy.getElementByTestId('dialog-button').then($element=>{
+            expect($element).to.be.visible;
+            expect($element.children()).contain('OK');
+            expect($element).to.have.attr('type','submit');
+            cy.wrap($element).click();
+        });
+    });
+});

--- a/cypress/support/reusable_tests/announcement.js
+++ b/cypress/support/reusable_tests/announcement.js
@@ -8,6 +8,7 @@ Cypress.Commands.add('testAnnouncementBannerElementsAndActions',(viewport)=>{
         expect($element).to.be.visible;
         expect($element).contain('Disclaimer');
         cy.wrap($element).click();
+        cy.wait(500);
         cy.getElementByTestId('dialog-container-title').then($element=>{
             expect($element).to.be.visible;
             expect($element).contain('AsylumConnect Disclaimer');
@@ -28,6 +29,7 @@ Cypress.Commands.add('testAnnouncementBannerElementsAndActions',(viewport)=>{
         expect($element).to.be.visible;
         expect($element).contain('User Privacy Statement');
         cy.wrap($element).click();
+        cy.wait(500);
         cy.getElementByTestId('dialog-container-title').then($element=>{
             expect($element).to.be.visible;
             expect($element).contain('AsylumConnect User Privacy Statement');

--- a/cypress/support/reusable_tests/language.js
+++ b/cypress/support/reusable_tests/language.js
@@ -6,21 +6,16 @@ Cypress.Commands.add('testLanguageAction',(viewport)=>{
             expect($element.children()).contain('Language');
             cy.wrap($element).click();
             cy.getElementByTestId('nav-button-language-item').then($element=>{
+                //Ensure it is French
+                expect($element[2]).contain("Français");
                 cy.wrap($element[2]).click();
             });
-            cy.wait(1000);
+            cy.wait(3000);
             cy.location().should(loc => {
                 expect(loc.href).to.be.eq('http://localhost:3000/#googtrans(fr)');
                 expect(loc.hostname).to.be.eq('localhost');
             });
-            cy.getElementByTestId('search-form-body-2').then($element=>{
-                expect($element).to.be.visible;
-               // expect($element).contain('Recherchez des services vérifiés adaptés aux LGBTQ et aux immigrants près de chez vous');
-            });
-            cy.getElementByTestId('search-page-next-button').then($element=>{
-                expect($element).to.be.visible;
-                expect($element.children()).contain('Suivant');
-            })
+            testMobile();
         });
     }else{
     let index = viewport === Cypress.env('desktop') ? 0 : 1;
@@ -28,31 +23,101 @@ Cypress.Commands.add('testLanguageAction',(viewport)=>{
         expect($element.children()).contain('English');
         cy.wrap($element[index]).click();
         cy.getElementByTestId('nav-button-language-item').then($element=>{
+            //Ensure it is French
+            expect($element[2]).contain("Français");
             cy.wrap($element[2]).click();
         });
-        cy.getElementByTestId('search-page-next-button').click();
         cy.location().should(loc => {
             expect(loc.href).to.be.eq('http://localhost:3000/#googtrans(fr)');
-            expect(loc.hostname).to.be.eq('localhost');
         });
-        cy.wait(1000);
-        cy.getElementByTestId('search-form-body').then($element=>{
-            expect($element).to.be.visible;
-            //expect($element).contain('Bienvenue dans le catalogue AsylumConnect des États-Unis!');
+        cy.getElementByTestId('search-page-next-button').click();
+        cy.wait(3000);
+        viewport === Cypress.env('desktop') ? testDesktop() : testTablet();
         });
-        cy.getElementByTestId('search-form-body-2').then($element=>{
-            expect($element).to.be.visible;
-            //expect($element).contain('Recherchez des services vérifiés adaptés aux LGBTQ et aux immigrants près de chez vous');
-        });
-        cy.getElementByTestId('search-bar-search-button').then($element=>{
-            expect($element).to.be.visible;
-            expect($element.children()).contain('Rechercher');
-        });
-        cy.getElementByTestId('search-form-download-link').then($element=>{
-            expect($element).to.be.visible;
-            expect($element.children()).contain("Téléchargez les guides juridiques sur l'asile LGBTQ aux États-Unis");
-        })
-
-    });
     };
 });
+
+
+function testDesktop(){
+    //Test Nav Bar Translations
+    cy.getElementByTestId('nav-button-about').then($element =>{
+        expect($element).to.be.visible;
+        expect($element).to.have.attr('href','https://asylumconnect.org/mission/');
+        expect($element.children()).contain("À propos de nous");
+    });
+                
+    cy.getElementByTestId('nav-button-take-action').then($element =>{
+        expect($element).to.be.visible;
+        expect($element).to.have.attr('href','https://asylumconnect.org/donate/');
+        expect($element.children()).contain("Passer à l'action");
+    });
+
+    cy.getElementByTestId('nav-button-get-help').then($element =>{
+        expect($element).to.be.visible;
+        expect($element).to.have.attr('href','https://asylumconnect.org/faqs/');
+        expect($element.children()).contain("Obtenir de l'aide");
+    });
+
+    cy.getElementByTestId('nav-button-contact').then($element =>{
+        expect($element).to.be.visible;
+        expect($element).to.have.attr('href','https://asylumconnect.org/contact/');
+        expect($element.children()).contain("Nous contacter");
+    });
+
+    cy.getElementByTestId('nav-button-safety-exit').then($element =>{
+        expect($element).to.be.visible;
+        expect($element).to.have.attr('href','https://www.google.com/');
+        expect($element.children()).contain("Sortie de sécurité");
+    });
+}
+
+function testTablet(){
+    cy.getElementByTestId('back-button').then($element=>{
+        expect($element).to.be.visible;
+        expect($element.children()).contain('Choisissez un autre pays');
+    });
+    cy.getElementByTestId('search-form-body-2').then($element=>{
+        expect($element).to.be.visible;
+        expect($element.children()).contain('Recherchez des services vérifiés adaptés aux LGBTQ et aux immigrants près de chez vous');
+    });
+    cy.getElementByTestId('search-bar-search-button').then($element=>{
+        expect($element).to.be.visible;
+        expect($element.children()).contain('Rechercher');
+    });
+    
+}
+
+function testMobile(){
+    cy.getElementByTestId('mobile-nav-button-search').then($element =>{
+        expect($element).to.be.visible;
+        expect($element).to.have.attr('type','button');
+        expect($element.children()).contain("Rechercher");
+       
+    });
+    
+    cy.getElementByTestId('mobile-nav-button-favorites').then($element =>{
+        expect($element).to.be.visible;
+        expect($element).to.have.attr('type','button');
+        expect($element.children()).contain("Favoris");
+        
+    });
+   
+    cy.getElementByTestId('mobile-nav-button-language').then($element =>{
+        expect($element).to.be.visible;
+        expect($element).to.have.attr('type','button');
+        expect($element.children()).contain("Langue");
+    });
+
+    cy.getElementByTestId('mobile-nav-button-account').then($element =>{
+        expect($element).to.be.visible;
+        expect($element).to.have.attr('type','button');
+        expect($element.children()).contain("Compte");
+       
+    });
+    
+    cy.getElementByTestId('mobile-nav-button-more').then($element=>{
+        expect($element).to.be.visible;
+        expect($element).to.have.attr('type','button');
+        expect($element.children()).contain("Suite");
+    });
+}

--- a/cypress/support/reusable_tests/language.js
+++ b/cypress/support/reusable_tests/language.js
@@ -30,11 +30,11 @@ Cypress.Commands.add('testLanguageAction',(viewport)=>{
         cy.getElementByTestId('nav-button-language-item').then($element=>{
             cy.wrap($element[2]).click();
         });
+        cy.getElementByTestId('search-page-next-button').click();
         cy.location().should(loc => {
             expect(loc.href).to.be.eq('http://localhost:3000/#googtrans(fr)');
             expect(loc.hostname).to.be.eq('localhost');
         });
-        cy.getElementByTestId('search-page-next-button').click();
         cy.wait(1000);
         cy.getElementByTestId('search-form-body').then($element=>{
             expect($element).to.be.visible;
@@ -47,6 +47,10 @@ Cypress.Commands.add('testLanguageAction',(viewport)=>{
         cy.getElementByTestId('search-bar-search-button').then($element=>{
             expect($element).to.be.visible;
             expect($element.children()).contain('Rechercher');
+        });
+        cy.getElementByTestId('search-form-download-link').then($element=>{
+            expect($element).to.be.visible;
+            expect($element.children()).contain("Téléchargez les guides juridiques sur l'asile LGBTQ aux États-Unis");
         })
 
     });

--- a/cypress/support/reusable_tests/language.js
+++ b/cypress/support/reusable_tests/language.js
@@ -1,0 +1,54 @@
+Cypress.Commands.add('testLanguageAction',(viewport)=>{
+    cy.viewport(viewport);
+    if(viewport === Cypress.env('mobile')){
+        cy.getElementByTestId('mobile-nav-button-language').then($element=>{
+            expect($element).to.have.attr('type','button');
+            expect($element.children()).contain('Language');
+            cy.wrap($element).click();
+            cy.getElementByTestId('nav-button-language-item').then($element=>{
+                cy.wrap($element[2]).click();
+            });
+            cy.wait(1000);
+            cy.location().should(loc => {
+                expect(loc.href).to.be.eq('http://localhost:3000/#googtrans(fr)');
+                expect(loc.hostname).to.be.eq('localhost');
+            });
+            cy.getElementByTestId('search-form-body-2').then($element=>{
+                expect($element).to.be.visible;
+               // expect($element).contain('Recherchez des services vérifiés adaptés aux LGBTQ et aux immigrants près de chez vous');
+            });
+            cy.getElementByTestId('search-page-next-button').then($element=>{
+                expect($element).to.be.visible;
+                expect($element.children()).contain('Suivant');
+            })
+        });
+    }else{
+    let index = viewport === Cypress.env('desktop') ? 0 : 1;
+    cy.getElementByTestId('nav-button-language').then($element=>{
+        expect($element.children()).contain('English');
+        cy.wrap($element[index]).click();
+        cy.getElementByTestId('nav-button-language-item').then($element=>{
+            cy.wrap($element[2]).click();
+        });
+        cy.location().should(loc => {
+            expect(loc.href).to.be.eq('http://localhost:3000/#googtrans(fr)');
+            expect(loc.hostname).to.be.eq('localhost');
+        });
+        cy.getElementByTestId('search-page-next-button').click();
+        cy.wait(1000);
+        cy.getElementByTestId('search-form-body').then($element=>{
+            expect($element).to.be.visible;
+            //expect($element).contain('Bienvenue dans le catalogue AsylumConnect des États-Unis!');
+        });
+        cy.getElementByTestId('search-form-body-2').then($element=>{
+            expect($element).to.be.visible;
+            //expect($element).contain('Recherchez des services vérifiés adaptés aux LGBTQ et aux immigrants près de chez vous');
+        });
+        cy.getElementByTestId('search-bar-search-button').then($element=>{
+            expect($element).to.be.visible;
+            expect($element.children()).contain('Rechercher');
+        })
+
+    });
+    };
+});

--- a/src/components/Announcement.js
+++ b/src/components/Announcement.js
@@ -4,69 +4,83 @@ import Typography from '@material-ui/core/Typography';
 import {withStyles} from '@material-ui/core/styles';
 
 const styles = (theme) => ({
-  announcement: {
-    backgroundColor: theme.palette.secondary[500],
-    padding: '2rem 0',
-    textAlign: 'center',
-  },
-  pointer: {
-    cursor: 'pointer',
-    display: 'inline-block',
-    position: 'relative',
-  },
-  pointerText: {
-    textShadow:
-      '2px 0 ' +
-      theme.palette.secondary[500] +
-      ', -2px 0 ' +
-      theme.palette.secondary[500],
-  },
-  underline: {
-    position: 'absolute',
-    width: '100%',
-    display: 'block',
-    margin: '0',
-    border: 'none',
-    height: '1px',
-    background: 'white',
-    bottom: '.2em',
-  },
-  textContent: {
-    color: theme.palette.common.darkWhite,
-    maxWidth: theme.maxColumnWidth,
-    margin: '0 auto',
-  },
+	announcement: {
+		backgroundColor: theme.palette.secondary[500],
+		padding: '2rem 0',
+		textAlign: 'center'
+	},
+	pointer: {
+		cursor: 'pointer',
+		display: 'inline-block',
+		position: 'relative'
+	},
+	pointerText: {
+		textShadow:
+			'2px 0 ' +
+			theme.palette.secondary[500] +
+			', -2px 0 ' +
+			theme.palette.secondary[500]
+	},
+	underline: {
+		position: 'absolute',
+		width: '100%',
+		display: 'block',
+		margin: '0',
+		border: 'none',
+		height: '1px',
+		background: 'white',
+		bottom: '.2em'
+	},
+	textContent: {
+		color: theme.palette.common.darkWhite,
+		maxWidth: theme.maxColumnWidth,
+		margin: '0 auto'
+	}
 });
 
 const Announcement = ({classes, handleRequestOpen}) => (
-  <div className={classes.announcement + ' hide--on-print'}>
-    <Typography variant="body1" className={classes.textContent}>
-      Users contact service providers at their own risk.
-      <br />
-      <span>Please read our complete </span>
-      <strong
-        className={classes.pointer}
-        onClick={() => handleRequestOpen('disclaimer')}
-      >
-        <i className={classes.underline} />
-        <span className={classes.pointerText}>Disclaimer</span>
-      </strong>
-      <span> and </span>
-      <strong
-        className={classes.pointer}
-        onClick={() => handleRequestOpen('privacy')}
-      >
-        <i className={classes.underline} />
-        <span className={classes.pointerText}>User Privacy Statement</span>
-      </strong>
-      <span> before using our catalog.</span>
-    </Typography>
-  </div>
+	<div className={classes.announcement + ' hide--on-print'}>
+		<Typography
+			variant="body1"
+			className={classes.textContent}
+			data-test-id="announcement-header"
+		>
+			Users contact service providers at their own risk.
+			<br />
+			<span>Please read our complete </span>
+			<strong
+				className={classes.pointer}
+				onClick={() => handleRequestOpen('disclaimer')}
+			>
+				<i className={classes.underline} />
+				<span
+					className={classes.pointerText}
+					data-test-id="announcement-disclaimer-button"
+				>
+					Disclaimer
+				</span>
+			</strong>
+			<span> and </span>
+			<strong
+				className={classes.pointer}
+				onClick={() => handleRequestOpen('privacy')}
+			>
+				<i className={classes.underline} />
+				<span
+					className={classes.pointerText}
+					data-test-id="announcement-privacy-button"
+				>
+					User Privacy Statement
+				</span>
+			</strong>
+			<span> before using our catalog.</span>
+		</Typography>
+	</div>
 );
 
 Announcement.propTypes = {
-  classes: PropTypes.object.isRequired,
-  handleRequestOpen: PropTypes.func.isRequired,
+	classes: PropTypes.object.isRequired,
+	handleRequestOpen: PropTypes.func.isRequired
 };
 
 export default withStyles(styles)(Announcement);

--- a/src/components/DialogButton.js
+++ b/src/components/DialogButton.js
@@ -6,27 +6,31 @@ import {withStyles} from '@material-ui/core/styles';
 import AsylumConnectButton from './AsylumConnectButton';
 
 const styles = (theme) => ({
-  buttonContainer: {
-    display: 'flex',
-    justifyContent: 'center',
-    marginTop: theme.spacing(4),
-  },
+	buttonContainer: {
+		display: 'flex',
+		justifyContent: 'center',
+		marginTop: theme.spacing(4)
+	}
 });
 
 const DialogButton = ({children, classes, handleRequestClose}) => (
-  <div className={classes.buttonContainer}>
-    <AsylumConnectButton onClick={handleRequestClose} variant="primary">
-      {children}
-    </AsylumConnectButton>
-  </div>
+	<div className={classes.buttonContainer}>
+		<AsylumConnectButton
+			onClick={handleRequestClose}
+			variant="primary"
+			testIdName="dialog-button"
+		>
+			{children}
+		</AsylumConnectButton>
+	</div>
 );
 
 DialogButton.propTypes = {
-  classes: PropTypes.shape({
-    buttonContainer: PropTypes.string,
-  }).isRequired,
-  children: PropTypes.node.isRequired,
-  handleRequestClose: PropTypes.func.isRequired,
+	classes: PropTypes.shape({
+		buttonContainer: PropTypes.string
+	}).isRequired,
+	children: PropTypes.node.isRequired,
+	handleRequestClose: PropTypes.func.isRequired
 };
 
 export default withStyles(styles)(DialogButton);

--- a/src/components/DisclaimerText.js
+++ b/src/components/DisclaimerText.js
@@ -7,7 +7,11 @@ const DisclaimerText = () => (
 		id="legal.disclaimer-full"
 		defaultMessage="The AsylumConnect team will do its best to confirm the eligibility and basic facts about service providers listed on this website. However, we cannot guarantee the viability or capabilities of any such providers. Consequently, AsylumConnect assumes no responsibility for the actions of providers listed on this website and asylum seekers who contact any such providers do so at their own risk."
 	>
-		{(disclaimer) => <Typography variant="body1">{disclaimer}</Typography>}
+		{(disclaimer) => (
+			<Typography variant="body1" data-test-id="disclaimer-text">
+				{disclaimer}
+			</Typography>
+		)}
 	</FormattedMessage>
 );
 

--- a/src/components/MapPage.js
+++ b/src/components/MapPage.js
@@ -77,9 +77,8 @@ class MapPage extends React.Component {
 		this.handleSortSelect = this.handleSortSelect.bind(this);
 		this.handleSearchButtonClick = this.handleSearchButtonClick.bind(this);
 		this.fetchSearchResults = this.fetchSearchResults.bind(this);
-		this.fetchNextSearchResultsPage = this.fetchNextSearchResultsPage.bind(
-			this
-		);
+		this.fetchNextSearchResultsPage =
+			this.fetchNextSearchResultsPage.bind(this);
 		this.handlePrintClick = this.handlePrintClick.bind(this);
 		this.processSearchResults = this.processSearchResults.bind(this);
 		this.setSelectedResource = this.setSelectedResource.bind(this);
@@ -388,13 +387,18 @@ class MapPage extends React.Component {
 				.then((results) => {
 					let state = '';
 					let city = '';
+					let county = '';
 
 					if (results.length && results[0].address_components) {
 						results[0].address_components.forEach((piece) => {
 							if (piece?.types?.indexOf('administrative_area_level_1') !== -1) {
 								state = piece?.long_name;
-							} else if (piece?.types?.indexOf('locality') !== -1) {
+							}
+							if (piece?.types?.indexOf('locality') !== -1) {
 								city = piece?.long_name;
+							}
+							if (piece?.types?.indexOf('administrative_area_level_2') !== -1) {
+								county = piece?.long_name.split(' ')[0];
 							}
 						});
 					}
@@ -427,7 +431,8 @@ class MapPage extends React.Component {
 							[]
 						),
 						state,
-						isNational
+						isNational,
+						county
 					};
 					this.setState(nextState);
 					localStorage.setItem(

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -69,7 +69,8 @@ export const fetchOrganizations = (params) => {
 		selectedFilters,
 		selectedResourceTypes,
 		state,
-		isNational
+		isNational,
+		county
 	} = params || {};
 	const tagLocale = localeTagMap[locale] || '';
 	const query = {};
@@ -113,14 +114,18 @@ export const fetchOrganizations = (params) => {
 		const stateProperty = `service-state-${getAreaId(state)}`;
 
 		serviceArea += `${serviceArea ? ',' : ''}${stateProperty}`;
+	}
+	if (county) {
+		const countyProperty = `service-county-${getAreaId(state)}-${getAreaId(
+			county
+		)}`;
 
-		if (city) {
-			const countyProperty = `service-county-${getAreaId(state)}-${getAreaId(
-				city
-			)}`;
+		serviceArea += `${serviceArea ? ',' : ''}${countyProperty}`;
+	}
+	if (city) {
+		const cityProperty = `service-city-${getAreaId(state)}-${getAreaId(city)}`;
 
-			serviceArea += `${serviceArea ? ',' : ''}${countyProperty}`;
-		}
+		serviceArea += `${serviceArea ? ',' : ''}${cityProperty}`;
 	}
 
 	if (serviceArea) {

--- a/src/utils/propertyMap.js
+++ b/src/utils/propertyMap.js
@@ -115,6 +115,7 @@ const propertyMap = {
 		'lang-mandarin': {code: 'zh'},
 		'lang-mandingo': {name: 'Mandingo'},
 		'lang-marathi': {code: 'mr'},
+		'lang-maya': {name: 'Maya'},
 		'lang-mexican-sign-language': {name: 'Mexican Sign Language (MSL)'},
 		'lang-mien': {name: 'Mien'},
 		'lang-mixteco': {name: 'Mixteco'},

--- a/src/utils/validLanguageList.js
+++ b/src/utils/validLanguageList.js
@@ -68,6 +68,7 @@ var validLangs = [
 	{name: 'Maltese'},
 	{name: 'Māori'},
 	{name: 'Marathi'},
+	{name: 'Maya'},
 	{name: 'Mixteco'},
 	{name: 'Mongolian'},
 	{name: 'Myanmar', 1: 'my', local: 'Burmese'},


### PR DESCRIPTION
## Description

- fixes typo in city property
- adds county explicitly as a service area in search query.


## Asana ticket:
 Reported by data entry intern: 

> Matt Martignoni (they/he) 
One of my organizations, Buffalo House, doesn’t appear when I try to find it on the public catalog. I checked the service area coverage and whether it was published and all seems like alright. Would you mind taking a look? @F.J. (he/him) (not sure you’re the right person to do this, it just seems technical)

## PR Checklist

<!-- Please validate your changes with the checklist below before marking for code review. -->

- [ ] Assign @FJKhan **and** @Alfredo-Moreira as reviewers.
- [x] If your PR is not a hotfix, is it targeted for `dev`? If it is a hotfix, is it targeted for `master`?
- [ ] Unit and functional test coverage was added where applicable.
- [ ] CI/CD passes for your PR.
- [ ] Complex code is well documented with comments.
- [ ] Does the original ticket have test instructions? If not add them below
- [ ] Pass QA Gate(manual testing)

## How to Test

1. Select an organization to verify results against. Ensure the org has a city and county service area property associated with it. For ease of testing, you can use Buffalo, NY for the city, and Erie, NY for the county.
2. Navigate to the catalog
2. Select USA ad the country
3. Search for organizations in "Buffalo, NY" or "Erie, NY"
4. Verify that the organization selected is included in the search results

<!-- Provide instructions for how to test/validate the changes. -->
![image](https://user-images.githubusercontent.com/7406914/126358723-2c1a1e26-76ca-4fb4-9341-d775dda19be1.png)

