### PR TITLE
adds maya lang property

### DIFF
--- a/src/utils/propertyMap.js
+++ b/src/utils/propertyMap.js
@@ -115,6 +115,7 @@ const propertyMap = {
 		'lang-mandarin': {code: 'zh'},
 		'lang-mandingo': {name: 'Mandingo'},
 		'lang-marathi': {code: 'mr'},
+		'lang-maya': {name: 'Maya'},
 		'lang-mexican-sign-language': {name: 'Mexican Sign Language (MSL)'},
 		'lang-mien': {name: 'Mien'},
 		'lang-mixteco': {name: 'Mixteco'},

--- a/src/utils/validLanguageList.js
+++ b/src/utils/validLanguageList.js
@@ -68,6 +68,7 @@ var validLangs = [
 	{name: 'Maltese'},
 	{name: 'Māori'},
 	{name: 'Marathi'},
+	{name: 'Maya'},
 	{name: 'Mixteco'},
 	{name: 'Mongolian'},
 	{name: 'Myanmar', 1: 'my', local: 'Burmese'},


### PR DESCRIPTION
## Description

- adds maya lang property

## Asana ticket:

Requested by data entry team

>Abby:
Let's flag FJ for that; can we add "Maya" to the list of language properties?

## PR Checklist

<!-- Please validate your changes with the checklist below before marking for code review. -->

- [x] Assign @FJKhan **and** @Alfredo-Moreira as reviewers.
- [x] If your PR is not a hotfix, is it targeted for `dev`? If it is a hotfix, is it targeted for `master`?
- [ ] Unit and functional test coverage was added where applicable.
- [ ] CI/CD passes for your PR.
- [x] Complex code is well documented with comments.
- [x] Does the original ticket have test instructions? If not add them below
- [ ] Pass QA Gate(manual testing)

## How to Test

1. Navigate to the Control Panel
2. Log in
3. Select an organization to view
4. Select a service to view
5. Navigate to the Properties tab
6. Click "Edit Properties"
7. Scroll down the properties dialog and observe that corresponding language property for Maya (lang-maya) is now available for selection
8. Select "lang-maya" and click "Save"
9. Click "View on Catalog" to see the updated service on the AC catalog
10. Observe that Mayais being displayed on the service page under "Language Services"

![image](https://user-images.githubusercontent.com/7406914/126407238-974dc143-e7f6-4a3b-a085-60601f21a6d4.png)

