### PR TITLE
show addresses in the U.S. Virgin Islands when searching in the US

### DIFF
--- a/src/components/SearchByLocation.js
+++ b/src/components/SearchByLocation.js
@@ -39,6 +39,10 @@ const SearchByLocation = (props) => {
 			country: typeof country === 'string' ? country.toLowerCase() : 'us'
 		}
 	};
+	//https://app.asana.com/0/1132189118126148/1202125382246302 find addresses in the U.S. Virgin Islands
+	if (searchOptions.componentRestrictions.country == 'us') {
+		searchOptions.componentRestrictions.country = ['us', 'vi'];
+	}
 	return (
 		<Grid item xs={12}>
 			<PlacesAutocomplete


### PR DESCRIPTION
## Description
we now have resources in the US Virgin Islands.
This PR adds the country code 'vi' to the country list when a user searches the US Catalog.
This instructs the google address api to list addresses for both the US and the US Virgin Islands

## Asana ticket:
https://app.asana.com/0/1132189118126148/1202125382246302

## PR Checklist

<!-- Please validate your changes with the checklist below before marking for code review. -->

- [ ] Assign @trigal2012 **and** @Alfredo-Moreira as reviewers.
- [ ] If your PR is not a hotfix, is it targeted for `dev`? If it is a hotfix, is it targeted for `main`?
- [ ] Unit and functional test coverage was added where applicable.
- [ ] CI/CD passes for your PR.
- [ ] Complex code is well documented with comments.
- [ ] Does the original ticket have test instructions? If not add them below
- [ ] Pass QA Gate(manual testing)

## How to Test
Test #1
1. in Control Panel create an organization with a location in the US Virgin Islands
2. in Catalog, use the look-a-head function to get the the US Virgin Islands to display (options can be Virgin Island, US Vir)
3. select the US Virgin Islands
4. verify the above Organization is listed

Test #2
1. in Control Panel create an organization with a service who's location is in the US Virgin Islands
2. in Catalog, use the look-a-head function to get the the US Virgin Islands to display (options can be Virgin Island, US Vir)
3. select the US Virgin Islands
4. verify the above Organization is listed
