### PR TITLE
fixing item instructions for 'other' service type

### DIFF
--- a/src/components/ResourceAccessInstructions.js
+++ b/src/components/ResourceAccessInstructions.js
@@ -258,7 +258,7 @@ const DetailAccessInstructions = (props) => {
 											<strong className={classes.boldFont}>
 												{item.access_value}:{' '}
 											</strong>{' '}
-											item.instructions
+											{item.instructions}
 										</Typography>
 									);
 							}


### PR DESCRIPTION
## Description
when a service type was 'other', the words 'item.instructions' was displayed instead of the property value of {item.instructions} 

## Asana ticket:
https://app.asana.com/0/1132189118126148/1202400749874922

## PR Checklist

<!-- Please validate your changes with the checklist below before marking for code review. -->

- [ ] Assign @trigal2012 **and** @Alfredo-Moreira as reviewers.
- [ ] If your PR is not a hotfix, is it targeted for `dev`? If it is a hotfix, is it targeted for `main`?
- [ ] Unit and functional test coverage was added where applicable.
- [ ] CI/CD passes for your PR.
- [ ] Complex code is well documented with comments.
- [ ] Does the original ticket have test instructions? If not add them below
- [ ] Pass QA Gate(manual testing)

## How to Test

<!-- Provide instructions for how to test/validate the changes. -->
