### PR TITLE
show youtube icon if org has a youtube profile

### DIFF
--- a/src/components/ResourceSocialMedia.js
+++ b/src/components/ResourceSocialMedia.js
@@ -2,13 +2,15 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {FacebookIcon, TwitterIcon, InstagramIcon} from './icons';
 import IconLink from './IconLink';
+import YouTube from '@material-ui/icons/YouTube';
 
 import {compose, prop, sortBy, toLower} from 'ramda';
 
 const mapping = {
 	facebook: FacebookIcon,
 	twitter: TwitterIcon,
-	instagram: InstagramIcon
+	instagram: InstagramIcon,
+	youtube: YouTube
 };
 
 const sortByPlatformName = sortBy(compose(toLower, prop('name')));


### PR DESCRIPTION
## Description
added a youtube icon (using material-ui icon) so a youtube link can be displayed if it is configured in control panel for an organization's social media profile

## Asana ticket:
https://app.asana.com/0/1132189118126148/1202392071458411

## PR Checklist

<!-- Please validate your changes with the checklist below before marking for code review. -->

- [ ] Assign @trigal2012 **and** @Alfredo-Moreira as reviewers.
- [ ] If your PR is not a hotfix, is it targeted for `dev`? If it is a hotfix, is it targeted for `main`?
- [ ] Unit and functional test coverage was added where applicable.
- [ ] CI/CD passes for your PR.
- [ ] Complex code is well documented with comments.
- [ ] Does the original ticket have test instructions? If not add them below
- [ ] Pass QA Gate(manual testing)

## How to Test
1. in control panel add youtube to an organizations Social Media section
2. in the catalog - search for that organization, ensure the youtube icon is present under the organizations title in the org detail view
<img width="300" src="https://user-images.githubusercontent.com/10123216/172303031-633b10df-a9f5-4f84-bd22-247c59a7cc3e.png">
<img width="300" src="https://user-images.githubusercontent.com/10123216/172303034-e04a232b-59a8-41d6-b9c4-77ef5c8d7f64.png">
<img width="300" src="https://user-images.githubusercontent.com/10123216/172303036-b5810a90-3051-4089-a571-139d2757dc3d.png">

