### PR TITLE
Feature - Catalog - update MiscIcon to show interlocking HelpingHands instead of 'AC'

### DIFF
--- a/src/components/DetailServices.js
+++ b/src/components/DetailServices.js
@@ -115,15 +115,26 @@ const Services = (props) => {
 											</Typography>
 										</>
 									) : (
-										<ACBadge
-											extraClasses={{
-												tooltip: classes.serviceTooltip
-											}}
-											key="misc"
-											type="misc"
-											width="45px"
-											height="45px"
-										/>
+										<>
+											<ACBadge
+												extraClasses={{
+													tooltip: classes.serviceTooltip
+												}}
+												key="misc"
+												type="misc"
+												width="45px"
+												height="45px"
+											/>
+											<Typography
+												variant="body2"
+												component="span"
+												className={classes.badge}
+											>
+												{intl.formatMessage({
+													id: 'service-type.other-services'
+												})}
+											</Typography>
+										</>
 									)}
 								</Grid>
 								<Grid item xs={12} md={9}>

--- a/src/components/icons/MiscIcon.js
+++ b/src/components/icons/MiscIcon.js
@@ -2,33 +2,41 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const ResourceMiscIcon = ({width, fillColor, strokeColor}) => (
-  <svg xmlns="http://www.w3.org/2000/svg" width={width} viewBox="0 0 35 37">
-    <defs>
-      <path id="a" d="M0 35V.075h34.925V35z" />
-    </defs>
-    <g fill="none" fillRule="evenodd">
-      <path
-        fill={fillColor}
-        d="M34.926 18.463c0 9.645-7.818 17.463-17.463 17.463C7.819 35.926 0 28.108 0 18.463 0 8.818 7.819 1 17.463 1c9.645 0 17.463 7.818 17.463 17.463"
-      />
-      <path
-        fill={strokeColor}
-        fillRule="nonzero"
-        d="M14.672 20.22h-4.35L8.828 24H8l4.307-10.752h.476L17 24h-.842l-1.487-3.78zm-4.08-.673h3.831l-1.457-3.86a18.75 18.75 0 0 1-.44-1.26c-.131.469-.276.894-.432 1.275l-1.501 3.845zm12.196-5.735c-1.343 0-2.4.43-3.172 1.29-.771.858-1.157 2.035-1.157 3.53 0 1.528.364 2.714 1.091 3.559.728.845 1.768 1.267 3.12 1.267a8.45 8.45 0 0 0 2.476-.344v.659c-.708.249-1.592.373-2.651.373-1.504 0-2.688-.485-3.553-1.457-.864-.972-1.296-2.33-1.296-4.072 0-1.09.206-2.049.619-2.879a4.479 4.479 0 0 1 1.78-1.922c.774-.452 1.673-.678 2.699-.678 1.045 0 1.98.195 2.805.586l-.3.674a5.433 5.433 0 0 0-2.461-.586z"
-      />
-    </g>
-  </svg>
+	<svg
+		width={width}
+		viewBox="0 2.06 523.875 504.568"
+		xmlns="http://www.w3.org/2000/svg"
+	>
+		<g
+			fill="none"
+			fillrule="evenodd"
+			transform="matrix(0.524546, 0, 0, 0.528675, 97.790863, 113.669998)"
+		>
+			<ellipse
+				stroke={strokeColor}
+				fill={fillColor}
+				cx="312.619"
+				cy="265.171"
+				rx="494.245"
+				ry="471.138"
+			/>
+			<path
+				fill="rgb(255, 255, 255)"
+				d="M 488 192 L 336 192 L 336 248 C 336 287.7 303.7 320 264 320 C 224.3 320 192 287.7 192 248 L 192 126.4 L 127.1 165.4 C 107.8 176.9 96 197.8 96 220.2 L 96 267.5 L 16 313.7 C 0.7 322.5 -4.6 342.1 4.3 357.4 L 84.3 496 C 93.1 511.3 112.7 516.5 128 507.7 L 231.4 448 L 368 448 C 403.3 448 432 419.3 432 384 L 448 384 C 465.7 384 480 369.7 480 352 L 480 288 L 488 288 C 501.3 288 512 277.3 512 264 L 512 216 C 512 202.7 501.3 192 488 192 Z M 635.7 154.6 L 555.7 16 C 546.9 0.7 527.3 -4.5 512 4.3 L 408.6 64 L 306.4 64 C 294.4 64 282.7 67.4 272.5 73.7 L 239 94.6 C 229.6 100.4 224 110.7 224 121.7 L 224 248 C 224 270.1 241.9 288 264 288 C 286.1 288 304 270.1 304 248 L 304 160 L 488 160 C 518.9 160 544 185.1 544 216 L 544 244.5 L 624 198.3 C 639.3 189.4 644.5 169.9 635.7 154.6 Z"
+			/>
+		</g>
+	</svg>
 );
 
 ResourceMiscIcon.defaultProps = {
-  width: '100%',
-  fillColor: '#5073B3',
-  strokeColor: '#FFF',
+	width: '110%',
+	fillColor: '#5073B3',
+	strokeColor: '#FFF'
 };
 ResourceMiscIcon.propTypes = {
-  width: PropTypes.string,
-  fillColor: PropTypes.string,
-  strokeColor: PropTypes.string,
+	width: PropTypes.string,
+	fillColor: PropTypes.string,
+	strokeColor: PropTypes.string
 };
 
 export default ResourceMiscIcon;


### PR DESCRIPTION
## Description
update MiscIcon to show interlocking HelpingHands instead of 'AC'
<img width="102" alt="helpingHandsMiscIcon" src="https://user-images.githubusercontent.com/10123216/177207707-8a61afd7-d44d-43f2-90ed-0254b9b73147.png">


## Asana ticket:
https://app.asana.com/0/1132189118126148/1202515609917969

## PR Checklist

<!-- Please validate your changes with the checklist below before marking for code review. -->

- [ ] Assign @trigal2012 **and** @Alfredo-Moreira as reviewers.
- [ ] If your PR is not a hotfix, is it targeted for `dev`? If it is a hotfix, is it targeted for `main`?
- [ ] Unit and functional test coverage was added where applicable.
- [ ] CI/CD passes for your PR.
- [ ] Complex code is well documented with comments.
- [ ] Does the original ticket have test instructions? If not add them below
- [ ] Pass QA Gate(manual testing)

## How to Test

<!-- Provide instructions for how to test/validate the changes. -->
