### PR TITLE
Hotfix - Catalog - Show only locations flagged as 'show on Org' - yes

### DIFF
--- a/src/components/AsylumConnectMap.js
+++ b/src/components/AsylumConnectMap.js
@@ -169,7 +169,7 @@ class AsylumConnectMap extends React.Component {
 								return points.map((location) => {
 									const {lat, lng} = getLatLong(location);
 
-									if (!lat || !lng) {
+									if (!lat || !lng || !location.show_on_organization) {
 										return null;
 									}
 

--- a/src/components/ResourceTypeSelector.js
+++ b/src/components/ResourceTypeSelector.js
@@ -330,8 +330,6 @@ const FilterCollection = (props) => {
 	}
 	const intl = useIntl();
 
-	console.log(categoryValue);
-
 	return (
 		<div
 			onMouseOver={onMouseOver}

--- a/src/components/ResourceVisit.js
+++ b/src/components/ResourceVisit.js
@@ -125,6 +125,10 @@ const Visit = ({
 			{locations && locations.length
 				? locations.map((location) => {
 						let schedule;
+
+						if (!location.show_on_organization) {
+							return null;
+						}
 						return (
 							<div
 								key={location._id}


### PR DESCRIPTION
## Description
if an address is entered in the back end(control panel) but has the 'show on org' flag set to "no", it was still displayed in the catalog.

This PR is to fix that issue so only addresses with the "show on Org" flag set to 'yes' are displayed in the catalog

AsylumConnectMap.js - (This is what shows the pin on the map) location now looks also for the 'show_on_organization' property = true rather than just lat and long values

ResourceVisit.js - (This is what shows the address in the locations list for the Organization) - location looks also for the 'show_on_organization' property = true

## Asana ticket:
https://app.asana.com/0/1132189118126148/1202549289660302

## PR Checklist

<!-- Please validate your changes with the checklist below before marking for code review. -->

- [ ] Assign @trigal2012 **and** @Alfredo-Moreira as reviewers.
- [ ] If your PR is not a hotfix, is it targeted for `dev`? If it is a hotfix, is it targeted for `main`?
- [ ] Unit and functional test coverage was added where applicable.
- [ ] CI/CD passes for your PR.
- [ ] Complex code is well documented with comments.
- [ ] Does the original ticket have test instructions? If not add them below
- [ ] Pass QA Gate(manual testing)

## How to Test

<!-- Provide instructions for how to test/validate the changes. -->
