### PR TITLE
Fix - InReach App - InReach logo link went to asylumconnect.org, now goes to home page of InReach App

### DIFF
--- a/src/components/SearchFormPage.js
+++ b/src/components/SearchFormPage.js
@@ -238,10 +238,7 @@ class SearchFormContainer extends React.Component {
 					<Grid container className={container}>
 						<Grid item class={mobileSubContainer}>
 							<Grid item xs={12} sm={12} className={mobileGridItem}>
-								<a
-									href="https://www.asylumconnect.org"
-									data-test-id="search-form-logo"
-								>
+								<a href="/" data-test-id="search-form-logo">
 									<IconButton className={iconButton}>
 										<img src={logo} alt="inreach logo" className={logoMobile} />
 									</IconButton>


### PR DESCRIPTION
## Description
On the mobile search page, clicking on the InReach logo, linked to the old  AsylumConnect URL. This fixes that and now clicking on the logo brings the user to the home page of the InReach App. 

## Asana ticket:
N/A

## PR Checklist

<!-- Please validate your changes with the checklist below before marking for code review. -->

- [ ] Assign @trigal2012 **and** @Alfredo-Moreira as reviewers.
- [ ] If your PR is not a hotfix, is it targeted for `dev`? If it is a hotfix, is it targeted for `main`?
- [ ] Unit and functional test coverage was added where applicable.
- [ ] CI/CD passes for your PR.
- [ ] Complex code is well documented with comments.
- [ ] Does the original ticket have test instructions? If not add them below
- [ ] Pass QA Gate(manual testing)

## How to Test

<!-- Provide instructions for how to test/validate the changes. -->
