### PR TITLE
Feature - InReach App  - adding the LinkedIn icon to details page

### DIFF
--- a/src/components/ResourceSocialMedia.js
+++ b/src/components/ResourceSocialMedia.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {FacebookIcon, TwitterIcon, InstagramIcon} from './icons';
+import {FacebookIcon, TwitterIcon, InstagramIcon, MiscIcon} from './icons';
 import IconLink from './IconLink';
 import YouTube from '@material-ui/icons/YouTube';
 import LinkedIn from '@material-ui/icons/LinkedIn';
 
-import {compose, prop, sortBy, toLower} from 'ramda';
+import {compose, prop, propOr, sortBy, toLower} from 'ramda';
 
 const mapping = {
 	facebook: FacebookIcon,
@@ -15,7 +15,7 @@ const mapping = {
 	linkedin: LinkedIn
 };
 
-const sortByPlatformName = sortBy(compose(toLower, prop('name')));
+const sortByPlatformName = sortBy(compose(toLower, propOr('noName', 'name')));
 
 const getSocialMediaLinks = ({
 	socialMedia,
@@ -24,16 +24,19 @@ const getSocialMediaLinks = ({
 	className,
 	isMobile = false
 }) => {
-	return sortByPlatformName(socialMedia).map(({name, url}) => (
-		<SocialMedia
-			iconWidth={iconWidth}
-			name={name}
-			url={url}
-			style={style}
-			className={className}
-			isMobile={isMobile}
-		/>
-	));
+	return sortByPlatformName(socialMedia).map(
+		({name, url}) =>
+			name && (
+				<SocialMedia
+					iconWidth={iconWidth}
+					name={name}
+					url={url}
+					style={style}
+					className={className}
+					isMobile={isMobile}
+				/>
+			)
+	);
 };
 
 const renderIcon = (iconWidth, name) => {

--- a/src/components/ResourceSocialMedia.js
+++ b/src/components/ResourceSocialMedia.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {FacebookIcon, TwitterIcon, InstagramIcon, MiscIcon} from './icons';
+import {FacebookIcon, TwitterIcon, InstagramIcon} from './icons';
 import IconLink from './IconLink';
 import YouTube from '@material-ui/icons/YouTube';
 import LinkedIn from '@material-ui/icons/LinkedIn';

--- a/src/components/ResourceSocialMedia.js
+++ b/src/components/ResourceSocialMedia.js
@@ -1,6 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {FacebookIcon, TwitterIcon, InstagramIcon} from './icons';
+import {
+	FacebookIcon,
+	TwitterIcon,
+	InstagramIcon,
+	SocialMediaMiscIcon
+} from './icons';
 import IconLink from './IconLink';
 import YouTube from '@material-ui/icons/YouTube';
 import LinkedIn from '@material-ui/icons/LinkedIn';
@@ -12,10 +17,11 @@ const mapping = {
 	twitter: TwitterIcon,
 	instagram: InstagramIcon,
 	youtube: YouTube,
-	linkedin: LinkedIn
+	linkedin: LinkedIn,
+	zmisc: SocialMediaMiscIcon
 };
 
-const sortByPlatformName = sortBy(compose(toLower, propOr('noName', 'name')));
+const sortByPlatformName = sortBy(compose(toLower, propOr('zname', 'name')));
 
 const getSocialMediaLinks = ({
 	socialMedia,
@@ -24,18 +30,26 @@ const getSocialMediaLinks = ({
 	className,
 	isMobile = false
 }) => {
-	return sortByPlatformName(socialMedia).map(
-		({name, url}) =>
-			name && (
-				<SocialMedia
-					iconWidth={iconWidth}
-					name={name}
-					url={url}
-					style={style}
-					className={className}
-					isMobile={isMobile}
-				/>
-			)
+	return sortByPlatformName(socialMedia).map(({name, url}) =>
+		name ? (
+			<SocialMedia
+				iconWidth={iconWidth}
+				name={name}
+				url={url}
+				style={style}
+				className={className}
+				isMobile={isMobile}
+			/>
+		) : (
+			<SocialMedia
+				iconWidth={iconWidth}
+				name={'zmisc'}
+				url={url}
+				style={style}
+				className={className}
+				isMobile={isMobile}
+			/>
+		)
 	);
 };
 

--- a/src/components/ResourceSocialMedia.js
+++ b/src/components/ResourceSocialMedia.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import {FacebookIcon, TwitterIcon, InstagramIcon} from './icons';
 import IconLink from './IconLink';
 import YouTube from '@material-ui/icons/YouTube';
+import LinkedIn from '@material-ui/icons/LinkedIn';
 
 import {compose, prop, sortBy, toLower} from 'ramda';
 
@@ -10,7 +11,8 @@ const mapping = {
 	facebook: FacebookIcon,
 	twitter: TwitterIcon,
 	instagram: InstagramIcon,
-	youtube: YouTube
+	youtube: YouTube,
+	linkedin: LinkedIn
 };
 
 const sortByPlatformName = sortBy(compose(toLower, prop('name')));

--- a/src/components/icons/MiscIcon.js
+++ b/src/components/icons/MiscIcon.js
@@ -1,12 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const ResourceMiscIcon = ({style, width, fillColor, strokeColor}) => (
+const ResourceMiscIcon = ({width, fillColor, strokeColor}) => (
 	<svg
-		style={style}
 		width={width}
 		viewBox="0 2.06 523.875 504.568"
-		// viewBox="0 0 16 16"
 		xmlns="http://www.w3.org/2000/svg"
 	>
 		<g
@@ -31,7 +29,7 @@ const ResourceMiscIcon = ({style, width, fillColor, strokeColor}) => (
 );
 
 ResourceMiscIcon.defaultProps = {
-	width: '100%',
+	width: '110%',
 	fillColor: '#5073B3',
 	strokeColor: '#FFF'
 };

--- a/src/components/icons/SocialMediaMiscIcon.js
+++ b/src/components/icons/SocialMediaMiscIcon.js
@@ -6,7 +6,6 @@ const SocialMediaMiscIcon = ({style, width, fillColor, strokeColor}) => (
 		style={style}
 		width={width}
 		viewBox="0 2.06 523.875 504.568"
-		// viewBox="0 0 16 16"
 		xmlns="http://www.w3.org/2000/svg"
 	>
 		<g

--- a/src/components/icons/SocialMediaMiscIcon.js
+++ b/src/components/icons/SocialMediaMiscIcon.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const ResourceMiscIcon = ({style, width, fillColor, strokeColor}) => (
+const SocialMediaMiscIcon = ({style, width, fillColor, strokeColor}) => (
 	<svg
 		style={style}
 		width={width}
@@ -30,15 +30,15 @@ const ResourceMiscIcon = ({style, width, fillColor, strokeColor}) => (
 	</svg>
 );
 
-ResourceMiscIcon.defaultProps = {
+SocialMediaMiscIcon.defaultProps = {
 	width: '100%',
-	fillColor: '#5073B3',
+	fillColor: '#4792DA',
 	strokeColor: '#FFF'
 };
-ResourceMiscIcon.propTypes = {
+SocialMediaMiscIcon.propTypes = {
 	width: PropTypes.string,
 	fillColor: PropTypes.string,
 	strokeColor: PropTypes.string
 };
 
-export default ResourceMiscIcon;
+export default SocialMediaMiscIcon;

--- a/src/components/icons/index.js
+++ b/src/components/icons/index.js
@@ -21,6 +21,7 @@ import MailIcon from './MailIcon';
 import MedicalIcon from './MedicalIcon';
 import MentalHealthIcon from './MentalHealthIcon';
 import MiscIcon from './MiscIcon';
+import SocialMediaMiscIcon from './SocialMediaMiscIcon';
 import PinpointIcon from './PinpointIcon';
 import PrivacyIcon from './PrivacyIcon';
 import RecommendedStarIcon from './RecommendedStarIcon';
@@ -57,6 +58,7 @@ export {default as MailIcon} from './MailIcon';
 export {default as MedicalIcon} from './MedicalIcon';
 export {default as MentalHealthIcon} from './MentalHealthIcon';
 export {default as MiscIcon} from './MiscIcon';
+export {default as SocialMediaMiscIcon} from './SocialMediaMiscIcon';
 export {default as MoreIcon} from './MoreIcon';
 export {default as PinpointIcon} from './PinpointIcon';
 export {default as PrivacyIcon} from './PrivacyIcon';
@@ -93,6 +95,7 @@ const typeMap = {
 	medical: MedicalIcon,
 	mentalHealth: MentalHealthIcon,
 	misc: MiscIcon,
+	socialMediaMisc: SocialMediaMiscIcon,
 	pinpoint: PinpointIcon,
 	privacy: PrivacyIcon,
 	search: SearchIcon,


### PR DESCRIPTION
## Description
adding support for the LinkedIn icon on the details page. If an Organization has been configured with a social media platform option in the Data Portal, that value will now appear in the details page.

If there is a link but no platform specified, display a generic icon (based on the MiscIcon)

## Asana ticket:

## PR Checklist

<!-- Please validate your changes with the checklist below before marking for code review. -->

- [ ] Assign @trigal2012 **and** @Alfredo-Moreira as reviewers.
- [ ] If your PR is not a hotfix, is it targeted for `dev`? If it is a hotfix, is it targeted for `main`?
- [ ] Unit and functional test coverage was added where applicable.
- [ ] CI/CD passes for your PR.
- [ ] Complex code is well documented with comments.
- [ ] Does the original ticket have test instructions? If not add them below
- [ ] Pass QA Gate(manual testing)

## How to Test

<!-- Provide instructions for how to test/validate the changes. -->
