### PR TITLE
FIX - InReach App - search results scrolled endlessly

### DIFF
--- a/src/components/MapPage.js
+++ b/src/components/MapPage.js
@@ -433,7 +433,9 @@ class MapPage extends React.Component {
 			searchDisabled: true,
 			printDisabled: true
 		});
+
 		const page = nextPage ? this.state.page + 1 : 1;
+
 		if (nearLatLng !== null) {
 			this.props.handleAddressChange(nearAddress);
 
@@ -491,6 +493,7 @@ class MapPage extends React.Component {
 					fetchOrganizations(params).then((data) =>
 						this.processSearchResults(data, nextPage)
 					);
+					this.setState(nextState);
 				})
 				.catch((error) => {
 					this.props.handleMessageNew(
@@ -519,7 +522,9 @@ class MapPage extends React.Component {
 			fetchOrganizations(params).then((data) =>
 				this.processSearchResults(data, nextPage)
 			);
+			this.setState(nextState);
 		}
+
 		this.setState(nextState);
 		if (this.props.match.path !== '/:locale/search/name') {
 			localStorage.setItem('lastSearch', this.props.history.location.pathname);


### PR DESCRIPTION
## Description
moved location to update this.state values in search results so pagination would work correctly

## Jira/Github issue ticket:
**no ticket** - reported via slack conversation
**The issue as reported**: ..."if I keep scrolling down I get the same orgs repeated over and over again"...
**Analysis**: This was an issue when there was more than 1 page worth of data returned from the search. 
to duplicate it:

- location is set to: “New York, NY, USA”
- distance is set to: “Nationally”
- Service Type is set to: “Community Support/Spiritual Support”

yields about 53 results.
This means there should be 3 pages of results in the App. The App however is getting stuck calling the 2nd page over and over again.
**Root Cause**: The state values for page and NextPage were not being updated in the correct place

## PR Checklist

<!-- Please validate your changes with the checklist below before marking for code review. -->

- [ ] Assign @trigal2012 **or** @Alfredo-Moreira as reviewers **as well as** @JoeKarow
- [ ] If your PR is not a hotfix, is it targeted for `dev`? If it is a hotfix, is it targeted for `main`?
- [ ] Unit and functional test coverage was added where applicable.
- [ ] CI/CD passes for your PR.
- [ ] Complex code is well documented with comments.
- [ ] Does the original ticket have test instructions? If not add them below
- [ ] Pass QA Gate(manual testing)

## How to Test

<!-- Provide instructions for how to test/validate the changes. -->
